### PR TITLE
Add SpaceXAPI and task tests

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0E911FF42236ECC900CBE217 /* NetworkSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */; };
 		0E911FF62236EDA300CBE217 /* SpaceXAPI+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */; };
 		0E911FF82236F64A00CBE217 /* XCTestCase+assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF72236F64A00CBE217 /* XCTestCase+assert.swift */; };
+		0E911FFA2237BBD600CBE217 /* SpaceXAPI+Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF92237BBD600CBE217 /* SpaceXAPI+Options.swift */; };
+		0E911FFC2237BBEE00CBE217 /* SpaceXAPIOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FFB2237BBEE00CBE217 /* SpaceXAPIOptionsTests.swift */; };
 		0EBCA1A822330CF500E8903F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA1A722330CF500E8903F /* AppDelegate.swift */; };
 		0EBCA1AF22330CF600E8903F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1AE22330CF600E8903F /* Assets.xcassets */; };
 		0EBCA1B222330CF600E8903F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1B022330CF600E8903F /* LaunchScreen.storyboard */; };
@@ -114,6 +116,8 @@
 		0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionProtocol.swift; sourceTree = "<group>"; };
 		0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceXAPI+Error.swift"; sourceTree = "<group>"; };
 		0E911FF72236F64A00CBE217 /* XCTestCase+assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+assert.swift"; sourceTree = "<group>"; };
+		0E911FF92237BBD600CBE217 /* SpaceXAPI+Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceXAPI+Options.swift"; sourceTree = "<group>"; };
+		0E911FFB2237BBEE00CBE217 /* SpaceXAPIOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceXAPIOptionsTests.swift; sourceTree = "<group>"; };
 		0EBCA1A422330CF500E8903F /* RocketFan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RocketFan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EBCA1A722330CF500E8903F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0EBCA1AE22330CF600E8903F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -308,6 +312,7 @@
 				E17553FE223555BA0033C136 /* SpaceXAPI.h */,
 				0E911FEC2236EAAA00CBE217 /* SpaceXAPI.swift */,
 				0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */,
+				0E911FF92237BBD600CBE217 /* SpaceXAPI+Options.swift */,
 			);
 			path = SpaceXAPI;
 			sourceTree = "<group>";
@@ -317,6 +322,7 @@
 			children = (
 				E175542022359F0F0033C136 /* EndpointsTests */,
 				E175540D223555BA0033C136 /* Info.plist */,
+				0E911FFB2237BBEE00CBE217 /* SpaceXAPIOptionsTests.swift */,
 				E175540B223555BA0033C136 /* SpaceXAPITests.swift */,
 				0E911FF02236EC6000CBE217 /* TestHelpers */,
 			);
@@ -616,6 +622,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E911FFA2237BBD600CBE217 /* SpaceXAPI+Options.swift in Sources */,
 				E175541A223582770033C136 /* Endpoint.swift in Sources */,
 				E175541F22359EE00033C136 /* Capsules.swift in Sources */,
 				E16820042236C86400E1EDDB /* Missions.swift in Sources */,
@@ -644,6 +651,7 @@
 				E1681FEC2236B2BB00E1EDDB /* HistoryTests.swift in Sources */,
 				E168200E2236CD7400E1EDDB /* RoadsterTests.swift in Sources */,
 				E1681FFE2236C28300E1EDDB /* LaunchPadsTests.swift in Sources */,
+				0E911FFC2237BBEE00CBE217 /* SpaceXAPIOptionsTests.swift in Sources */,
 				E1681FF02236B8A600E1EDDB /* InfoTests.swift in Sources */,
 				E168200A2236CB5B00E1EDDB /* RocketsTests.swift in Sources */,
 				E175540C223555BA0033C136 /* SpaceXAPITests.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -9,6 +9,11 @@
 /* Begin PBXBuildFile section */
 		0E611C11223312BE00F85DAB /* RocketFanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C10223312BE00F85DAB /* RocketFanTests.swift */; };
 		0E611C13223312C800F85DAB /* RocketFanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C12223312C800F85DAB /* RocketFanUITests.swift */; };
+		0E911FED2236EAAA00CBE217 /* SpaceXAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FEC2236EAAA00CBE217 /* SpaceXAPI.swift */; };
+		0E911FEF2236EB5A00CBE217 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FEE2236EB5A00CBE217 /* Result.swift */; };
+		0E911FF22236EC7A00CBE217 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF12236EC7A00CBE217 /* TestHelpers.swift */; };
+		0E911FF42236ECC900CBE217 /* NetworkSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */; };
+		0E911FF62236EDA300CBE217 /* SpaceXAPI+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */; };
 		0EBCA1A822330CF500E8903F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA1A722330CF500E8903F /* AppDelegate.swift */; };
 		0EBCA1AF22330CF600E8903F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1AE22330CF600E8903F /* Assets.xcassets */; };
 		0EBCA1B222330CF600E8903F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1B022330CF600E8903F /* LaunchScreen.storyboard */; };
@@ -102,6 +107,11 @@
 		0E2EA408223519D600A7D350 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		0E611C10223312BE00F85DAB /* RocketFanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanTests.swift; sourceTree = "<group>"; };
 		0E611C12223312C800F85DAB /* RocketFanUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanUITests.swift; sourceTree = "<group>"; };
+		0E911FEC2236EAAA00CBE217 /* SpaceXAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceXAPI.swift; sourceTree = "<group>"; };
+		0E911FEE2236EB5A00CBE217 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		0E911FF12236EC7A00CBE217 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionProtocol.swift; sourceTree = "<group>"; };
+		0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceXAPI+Error.swift"; sourceTree = "<group>"; };
 		0EBCA1A422330CF500E8903F /* RocketFan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RocketFan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EBCA1A722330CF500E8903F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0EBCA1AE22330CF600E8903F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -188,6 +198,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E911FF02236EC6000CBE217 /* TestHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				0E911FF12236EC7A00CBE217 /* TestHelpers.swift */,
+			);
+			path = TestHelpers;
+			sourceTree = "<group>";
+		};
 		0EBCA19B22330CF500E8903F = {
 			isa = PBXGroup;
 			children = (
@@ -281,8 +299,12 @@
 			isa = PBXGroup;
 			children = (
 				E175541B223582BA0033C136 /* Endpoints */,
-				E17553FE223555BA0033C136 /* SpaceXAPI.h */,
 				E17553FF223555BA0033C136 /* Info.plist */,
+				0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */,
+				0E911FEE2236EB5A00CBE217 /* Result.swift */,
+				E17553FE223555BA0033C136 /* SpaceXAPI.h */,
+				0E911FEC2236EAAA00CBE217 /* SpaceXAPI.swift */,
+				0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */,
 			);
 			path = SpaceXAPI;
 			sourceTree = "<group>";
@@ -291,8 +313,9 @@
 			isa = PBXGroup;
 			children = (
 				E175542022359F0F0033C136 /* EndpointsTests */,
-				E175540B223555BA0033C136 /* SpaceXAPITests.swift */,
 				E175540D223555BA0033C136 /* Info.plist */,
+				E175540B223555BA0033C136 /* SpaceXAPITests.swift */,
+				0E911FF02236EC6000CBE217 /* TestHelpers */,
 			);
 			path = SpaceXAPITests;
 			sourceTree = "<group>";
@@ -593,8 +616,11 @@
 				E175541A223582770033C136 /* Endpoint.swift in Sources */,
 				E175541F22359EE00033C136 /* Capsules.swift in Sources */,
 				E16820042236C86400E1EDDB /* Missions.swift in Sources */,
+				0E911FF42236ECC900CBE217 /* NetworkSessionProtocol.swift in Sources */,
 				E168200C2236CB7900E1EDDB /* Rockets.swift in Sources */,
+				0E911FED2236EAAA00CBE217 /* SpaceXAPI.swift in Sources */,
 				E1681FF62236BB4700E1EDDB /* LandingPads.swift in Sources */,
+				0E911FEF2236EB5A00CBE217 /* Result.swift in Sources */,
 				E16820152236CEDB00E1EDDB /* Ships.swift in Sources */,
 				E1681FEA2236B04D00E1EDDB /* Dragons.swift in Sources */,
 				E1681FFC2236BE7D00E1EDDB /* Launches.swift in Sources */,
@@ -604,6 +630,7 @@
 				E1681FE42236ABE800E1EDDB /* Cores.swift in Sources */,
 				E1681FEE2236B2F700E1EDDB /* History.swift in Sources */,
 				E16820082236C9FC00E1EDDB /* Payloads.swift in Sources */,
+				0E911FF62236EDA300CBE217 /* SpaceXAPI+Error.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -622,6 +649,7 @@
 				E16820022236C81E00E1EDDB /* MissionsTests.swift in Sources */,
 				E175542222359F2F0033C136 /* CapsulesTests.swift in Sources */,
 				E1681FE82236AFED00E1EDDB /* DragonsTests.swift in Sources */,
+				0E911FF22236EC7A00CBE217 /* TestHelpers.swift in Sources */,
 				E16820122236CE6D00E1EDDB /* ShipsTests.swift in Sources */,
 				E1681FE62236AC2C00E1EDDB /* CoresTests.swift in Sources */,
 				E16820062236C9C200E1EDDB /* PayloadsTests.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0E911FF22236EC7A00CBE217 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF12236EC7A00CBE217 /* TestHelpers.swift */; };
 		0E911FF42236ECC900CBE217 /* NetworkSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */; };
 		0E911FF62236EDA300CBE217 /* SpaceXAPI+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */; };
+		0E911FF82236F64A00CBE217 /* XCTestCase+assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E911FF72236F64A00CBE217 /* XCTestCase+assert.swift */; };
 		0EBCA1A822330CF500E8903F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA1A722330CF500E8903F /* AppDelegate.swift */; };
 		0EBCA1AF22330CF600E8903F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1AE22330CF600E8903F /* Assets.xcassets */; };
 		0EBCA1B222330CF600E8903F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0EBCA1B022330CF600E8903F /* LaunchScreen.storyboard */; };
@@ -112,6 +113,7 @@
 		0E911FF12236EC7A00CBE217 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		0E911FF32236ECC900CBE217 /* NetworkSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionProtocol.swift; sourceTree = "<group>"; };
 		0E911FF52236EDA300CBE217 /* SpaceXAPI+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceXAPI+Error.swift"; sourceTree = "<group>"; };
+		0E911FF72236F64A00CBE217 /* XCTestCase+assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+assert.swift"; sourceTree = "<group>"; };
 		0EBCA1A422330CF500E8903F /* RocketFan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RocketFan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EBCA1A722330CF500E8903F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0EBCA1AE22330CF600E8903F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				0E911FF12236EC7A00CBE217 /* TestHelpers.swift */,
+				0E911FF72236F64A00CBE217 /* XCTestCase+assert.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -644,6 +647,7 @@
 				E1681FF02236B8A600E1EDDB /* InfoTests.swift in Sources */,
 				E168200A2236CB5B00E1EDDB /* RocketsTests.swift in Sources */,
 				E175540C223555BA0033C136 /* SpaceXAPITests.swift in Sources */,
+				0E911FF82236F64A00CBE217 /* XCTestCase+assert.swift in Sources */,
 				E1681FF42236BAF500E1EDDB /* LandingPadsTests.swift in Sources */,
 				E1681FFA2236BE3300E1EDDB /* LaunchesTests.swift in Sources */,
 				E16820022236C81E00E1EDDB /* MissionsTests.swift in Sources */,

--- a/SpaceXAPI/Endpoints/Endpoint.swift
+++ b/SpaceXAPI/Endpoints/Endpoint.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol Endpoint {
+public protocol Endpoint {
     var path: String { get }
 }

--- a/SpaceXAPI/NetworkSessionProtocol.swift
+++ b/SpaceXAPI/NetworkSessionProtocol.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Defines a NetworkSession protocol to allow easier testing
+public protocol NetworkSession {
+    func dataTask(with url: URL,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}
+
+/// Conform `URLSession` to `NetworkSession`
+extension URLSession: NetworkSession { }

--- a/SpaceXAPI/Result.swift
+++ b/SpaceXAPI/Result.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum Result<Data> {
+    case success(Data)
+    case error(Error)
+}

--- a/SpaceXAPI/SpaceXAPI+Error.swift
+++ b/SpaceXAPI/SpaceXAPI+Error.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum SpaceXAPIError: Error {
+    case unknownReponse
+    case serverReturnedCode(Int)
+    case noDataReceived
+}
+
+extension SpaceXAPIError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .unknownReponse:
+            return NSLocalizedString("Server returned unknown response", comment: "Server returned unknown response")
+
+        case .serverReturnedCode(let code):
+            return NSLocalizedString("Server returned HTTP code \(code)", comment: "Server returned code")
+
+        case .noDataReceived:
+            return NSLocalizedString("No data returned by the server", comment: "Missing data error")
+        }
+    }
+}

--- a/SpaceXAPI/SpaceXAPI+Error.swift
+++ b/SpaceXAPI/SpaceXAPI+Error.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum SpaceXAPIError: Error {
-    case unknownReponse
+    case unknownResponse
     case serverReturnedCode(Int)
     case noDataReceived
 }
@@ -9,7 +9,7 @@ enum SpaceXAPIError: Error {
 extension SpaceXAPIError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .unknownReponse:
+        case .unknownResponse:
             return NSLocalizedString("Server returned unknown response", comment: "Server returned unknown response")
 
         case .serverReturnedCode(let code):

--- a/SpaceXAPI/SpaceXAPI+Error.swift
+++ b/SpaceXAPI/SpaceXAPI+Error.swift
@@ -3,7 +3,7 @@ import Foundation
 enum SpaceXAPIError: Error {
     case unknownResponse
     case serverReturnedCode(Int)
-    case noDataReceived
+    case emptyResponse
 }
 
 extension SpaceXAPIError: LocalizedError {
@@ -15,7 +15,7 @@ extension SpaceXAPIError: LocalizedError {
         case .serverReturnedCode(let code):
             return NSLocalizedString("Server returned HTTP code \(code)", comment: "Server returned code")
 
-        case .noDataReceived:
+        case .emptyResponse:
             return NSLocalizedString("No data returned by the server", comment: "Missing data error")
         }
     }

--- a/SpaceXAPI/SpaceXAPI+Options.swift
+++ b/SpaceXAPI/SpaceXAPI+Options.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public extension SpaceXAPI {
+    public struct Options {
+        public var queryItems: [URLQueryItem] {
+            var parameters: [String: String] = [:]
+
+            if let options = filterOptions {
+                parameters["filter"] = options.joined(separator: ",")
+            }
+
+            parameters["limit"] = String(limit)
+            parameters["offset"] = String(offset)
+
+            return parameters.map { URLQueryItem(name: $0, value: $1) }
+        }
+
+        private let filterOptions: [String]?
+        private let limit: Int
+        private let offset: Int
+
+        /// Create result query options
+        ///
+        /// - Parameters:
+        ///   - filterOptions: An optional array of query fields. If this is set then only these values will be returned
+        ///   by the API. For example, specifying `flight_number` will only return `flight_number` values from the API.
+        ///   - limit: Page limit to be returned, defaults to `25`
+        ///   - offset: Page offset, defaults to `0`
+        public init(filterOptions: [String]? = nil, limit: Int = 25, offset: Int = 0) {
+            self.filterOptions = filterOptions
+            self.limit = limit
+            self.offset = offset
+        }
+    }
+}

--- a/SpaceXAPI/SpaceXAPI.swift
+++ b/SpaceXAPI/SpaceXAPI.swift
@@ -31,7 +31,7 @@ final public class SpaceXAPI {
             }
 
             guard let data = data else {
-                completion(Result.error(SpaceXAPIError.noDataReceived))
+                completion(Result.error(SpaceXAPIError.emptyResponse))
                 return
             }
 

--- a/SpaceXAPI/SpaceXAPI.swift
+++ b/SpaceXAPI/SpaceXAPI.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+final public class SpaceXAPI {
+    private let baseURL = URL(string: "https://api.spacexdata.com/v3")!
+    private let urlSession: NetworkSession
+
+    public init(urlSession: NetworkSession) {
+        self.urlSession = urlSession
+    }
+
+    public func get(_ endpoint: Endpoint,
+                    parameters: [String: String]? = nil,
+                    completion: @escaping (Result<Data>) -> Void) -> URLSessionTask {
+
+        let url = buildURL(for: endpoint, using: parameters)
+
+        let task = urlSession.dataTask(with: url) { data, urlResponse, error in
+            if let error = error {
+                completion(Result.error(error))
+                return
+            }
+
+            guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                completion(Result.error(SpaceXAPIError.unknownReponse))
+                return
+            }
+
+            guard (200 ..< 300).contains(httpResponse.statusCode) else {
+                completion(Result.error(SpaceXAPIError.serverReturnedCode(httpResponse.statusCode)))
+                return
+            }
+
+            guard let data = data else {
+                completion(Result.error(SpaceXAPIError.noDataReceived))
+                return
+            }
+
+            completion(Result.success(data))
+        }
+
+        task.resume()
+
+        return task
+    }
+
+    private func buildURL(for endpoint: Endpoint, using parameters: [String: String]?) -> URL {
+        let url = baseURL.appendingPathComponent(endpoint.path)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = parameters?.map { URLQueryItem(name: $0, value: $1) }
+        return components?.url ?? url
+    }
+}

--- a/SpaceXAPI/SpaceXAPI.swift
+++ b/SpaceXAPI/SpaceXAPI.swift
@@ -9,10 +9,10 @@ final public class SpaceXAPI {
     }
 
     public func get(_ endpoint: Endpoint,
-                    parameters: [String: String]? = nil,
+                    options: Options? = nil,
                     completion: @escaping (Result<Data>) -> Void) -> URLSessionTask {
 
-        let url = buildURL(for: endpoint, using: parameters)
+        let url = buildURL(for: endpoint, using: options)
 
         let task = urlSession.dataTask(with: url) { data, urlResponse, error in
             if let error = error {
@@ -43,10 +43,14 @@ final public class SpaceXAPI {
         return task
     }
 
-    private func buildURL(for endpoint: Endpoint, using parameters: [String: String]?) -> URL {
+    private func buildURL(for endpoint: Endpoint, using options: Options?) -> URL {
         let url = baseURL.appendingPathComponent(endpoint.path)
+
+        guard let options = options else { return url }
+
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        components?.queryItems = parameters?.map { URLQueryItem(name: $0, value: $1) }
+        components?.queryItems = options.queryItems
+
         return components?.url ?? url
     }
 }

--- a/SpaceXAPI/SpaceXAPI.swift
+++ b/SpaceXAPI/SpaceXAPI.swift
@@ -21,7 +21,7 @@ final public class SpaceXAPI {
             }
 
             guard let httpResponse = urlResponse as? HTTPURLResponse else {
-                completion(Result.error(SpaceXAPIError.unknownReponse))
+                completion(Result.error(SpaceXAPIError.unknownResponse))
                 return
             }
 

--- a/SpaceXAPITests/SpaceXAPIOptionsTests.swift
+++ b/SpaceXAPITests/SpaceXAPIOptionsTests.swift
@@ -48,4 +48,12 @@ class SpaceXAPIOptionsTests: XCTestCase {
         let expectedItem = URLQueryItem(name: "offset", value: String(offset))
         XCTAssertTrue(queryItems.contains(expectedItem), "\(queryItems) does not contain \(expectedItem)")
     }
+
+    func test_SpaceXAPIOptions_ReturnsCorrectNumberOfQueryItems() {
+        let options = SpaceXAPI.Options(filterOptions: ["flight_number"], limit: 1, offset: 1)
+
+        let queryItems = options.queryItems
+
+        XCTAssertEqual(queryItems.count, 3)
+    }
 }

--- a/SpaceXAPITests/SpaceXAPIOptionsTests.swift
+++ b/SpaceXAPITests/SpaceXAPIOptionsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import SpaceXAPI
+
+class SpaceXAPIOptionsTests: XCTestCase {
+    func test_SpaceXAPIOptions_ShouldHaveDefaultLimit() {
+        let options = SpaceXAPI.Options()
+
+        let queryItems = options.queryItems
+
+        XCTAssertNotNil(queryItems.first(where: { $0.name == "limit" }), "\(queryItems) does not contain limit query")
+    }
+
+    func test_SpaceXAPIOptions_ShouldHaveDefaultOffset() {
+        let options = SpaceXAPI.Options()
+
+        let queryItems = options.queryItems
+
+        XCTAssertNotNil(queryItems.first(where: { $0.name == "offset" }), "\(queryItems) does not contain offset query")
+    }
+
+    func test_SpaceXAPIOptions_WithFilterOptions_CreatesQueryItems() {
+        let option = "flight_number"
+        let filterOptions = [option]
+        let options = SpaceXAPI.Options(filterOptions: filterOptions)
+
+        let queryItems = options.queryItems
+
+        let expectedItem = URLQueryItem(name: "filter", value: option)
+        XCTAssertTrue(queryItems.contains(expectedItem), "\(queryItems) did not contain \(expectedItem)")
+    }
+
+    func test_SpaceXAPIOptions_ShouldHaveSpecifiedLimit() {
+        let limit = 1
+        let options = SpaceXAPI.Options(limit: limit)
+
+        let queryItems = options.queryItems
+
+        let expectedItem = URLQueryItem(name: "limit", value: String(limit))
+        XCTAssertTrue(queryItems.contains(expectedItem), "\(queryItems) does not contain \(expectedItem)")
+    }
+
+    func test_SpaceXAPIOptions_ShouldHaveSpecifiedOffset() {
+        let offset = 1
+        let options = SpaceXAPI.Options(offset: offset)
+
+        let queryItems = options.queryItems
+
+        let expectedItem = URLQueryItem(name: "offset", value: String(offset))
+        XCTAssertTrue(queryItems.contains(expectedItem), "\(queryItems) does not contain \(expectedItem)")
+    }
+}

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -111,4 +111,3 @@ class SpaceXAPITests: XCTestCase {
         assert(returnedResult, containsData: data)
     }
 }
-

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -5,14 +5,26 @@ import XCTest
 class SpaceXAPITests: XCTestCase {
     var api: SpaceXAPI!
     var sessionMock = SessionMock()
+    let endpoint = EndpointMock()
+    var okResponse: HTTPURLResponse!
+    var badResponse: HTTPURLResponse!
 
     override func setUp() {
+        let url = URL(fileURLWithPath: "")
+        okResponse = HTTPURLResponse(url: url,
+                                     statusCode: 200,
+                                     httpVersion: nil,
+                                     headerFields: nil)
+
+        badResponse = HTTPURLResponse(url: url,
+                                      statusCode: 404,
+                                      httpVersion: nil,
+                                      headerFields: nil)
+
         api = SpaceXAPI(urlSession: sessionMock)
     }
 
     func test_SpaceXAPI_BuildsURL() {
-        let endpoint = EndpointMock()
-
         _ = api.get(endpoint) { _ in }
 
         XCTAssertEqual(sessionMock.urlCalled, "https://api.spacexdata.com/v3/test")
@@ -22,7 +34,7 @@ class SpaceXAPITests: XCTestCase {
         let taskMock = DataTaskMock()
         sessionMock.task = taskMock
 
-        let task = api.get(EndpointMock()) { _ in }
+        let task = api.get(endpoint) { _ in }
 
         XCTAssertEqual(task, taskMock)
     }
@@ -31,8 +43,71 @@ class SpaceXAPITests: XCTestCase {
         let taskMock = DataTaskMock()
         sessionMock.task = taskMock
 
-        _ = api.get(EndpointMock()) { _ in }
+        _ = api.get(endpoint) { _ in }
 
         XCTAssertTrue(taskMock.resumeWasCalled)
     }
+
+    func test_SpaceXAPI_WhenGivenError_ReturnsError() {
+        let expectedError = ErrorMock.expected
+        sessionMock.error = expectedError
+
+        var returnedResult: Result<Data>?
+        _ = api.get(endpoint) { result in
+            returnedResult = result
+        }
+
+        assert(returnedResult, containsError: expectedError)
+    }
+
+    func test_SpaceXAPI_WhenGivenEmptyResponse_ReturnsUnknownResponseError() {
+        let expectedError = SpaceXAPIError.unknownResponse
+        sessionMock.response = nil
+
+        var returnedResult: Result<Data>?
+        _ = api.get(endpoint) { result in
+            returnedResult = result
+        }
+
+        assert(returnedResult, containsError: expectedError)
+    }
+
+    func test_SpaceXAPI_WhenGivenServerError_ReturnsError() {
+        let error = SpaceXAPIError.serverReturnedCode(404)
+        sessionMock.response = badResponse
+
+        var returnedResult: Result<Data>?
+        _ = api.get(endpoint) { result in
+            returnedResult = result
+        }
+
+        assert(returnedResult, containsError: error)
+    }
+
+    func test_SpaceXAPI_WhenGivenNoData_ReturnsNoDataError() {
+        let error = SpaceXAPIError.noDataReceived
+        sessionMock.response = okResponse
+        sessionMock.data = nil
+
+        var returnedResult: Result<Data>?
+        _ = api.get(endpoint) { result in
+            returnedResult = result
+        }
+
+        assert(returnedResult, containsError: error)
+    }
+
+    func test_SpaceXAPI_WhenGivenData_ReturnsSuccess() {
+        let data = "Blast off".data(using: .utf8)!
+        sessionMock.response = okResponse
+        sessionMock.data = data
+
+        var returnedResult: Result<Data>?
+        _ = api.get(endpoint) { result in
+            returnedResult = result
+        }
+
+        assert(returnedResult, containsData: data)
+    }
 }
+

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -31,12 +31,14 @@ class SpaceXAPITests: XCTestCase {
         XCTAssertEqual(sessionMock.calledURL, expectedURL)
     }
 
-    func test_SpaceXAPI_BuildsURL_WithParameters() {
-        let parameters = ["params": "true"]
-        _ = api.get(endpoint, parameters: parameters) { _ in }
+    func test_SpaceXAPI_BuildsURL_WithOptions() {
+        let options = SpaceXAPI.Options(limit: 1, offset: 2)
 
-        let expectedURL = URL(string: "https://api.spacexdata.com/v3/test?params=true")
-        XCTAssertEqual(sessionMock.calledURL, expectedURL)
+        _ = api.get(endpoint, options: options) { _ in }
+
+        // Query item order isn't guaranteed, so don't try and match an absolute string
+        let components = URLComponents(url: sessionMock.calledURL!, resolvingAgainstBaseURL: false)!
+        XCTAssertEqual(components.queryItems, options.queryItems)
     }
 
     func test_SpaceXAPI_ReturnsTask() {

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -31,6 +31,14 @@ class SpaceXAPITests: XCTestCase {
         XCTAssertEqual(sessionMock.calledURL, expectedURL)
     }
 
+    func test_SpaceXAPI_BuildsURL_WithParameters() {
+        let parameters = ["params": "true"]
+        _ = api.get(endpoint, parameters: parameters) { _ in }
+
+        let expectedURL = URL(string: "https://api.spacexdata.com/v3/test?params=true")
+        XCTAssertEqual(sessionMock.calledURL, expectedURL)
+    }
+
     func test_SpaceXAPI_ReturnsTask() {
         let taskMock = DataTaskMock()
         sessionMock.task = taskMock

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -27,7 +27,8 @@ class SpaceXAPITests: XCTestCase {
     func test_SpaceXAPI_BuildsURL() {
         _ = api.get(endpoint) { _ in }
 
-        XCTAssertEqual(sessionMock.urlCalled, "https://api.spacexdata.com/v3/test")
+        let expectedURL = URL(string: "https://api.spacexdata.com/v3/test")
+        XCTAssertEqual(sessionMock.calledURL, expectedURL)
     }
 
     func test_SpaceXAPI_ReturnsTask() {
@@ -85,7 +86,7 @@ class SpaceXAPITests: XCTestCase {
     }
 
     func test_SpaceXAPI_WhenGivenNoData_ReturnsNoDataError() {
-        let error = SpaceXAPIError.noDataReceived
+        let error = SpaceXAPIError.emptyResponse
         sessionMock.response = okResponse
         sessionMock.data = nil
 

--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -1,26 +1,38 @@
+// swiftlint:disable implicitly_unwrapped_optional
 import XCTest
 @testable import SpaceXAPI
 
 class SpaceXAPITests: XCTestCase {
+    var api: SpaceXAPI!
+    var sessionMock = SessionMock()
 
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        api = SpaceXAPI(urlSession: sessionMock)
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func test_SpaceXAPI_BuildsURL() {
+        let endpoint = EndpointMock()
+
+        _ = api.get(endpoint) { _ in }
+
+        XCTAssertEqual(sessionMock.urlCalled, "https://api.spacexdata.com/v3/test")
     }
 
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func test_SpaceXAPI_ReturnsTask() {
+        let taskMock = DataTaskMock()
+        sessionMock.task = taskMock
+
+        let task = api.get(EndpointMock()) { _ in }
+
+        XCTAssertEqual(task, taskMock)
     }
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+    func test_SpaceXAPI_ResumesTask() {
+        let taskMock = DataTaskMock()
+        sessionMock.task = taskMock
 
+        _ = api.get(EndpointMock()) { _ in }
+
+        XCTAssertTrue(taskMock.resumeWasCalled)
+    }
 }

--- a/SpaceXAPITests/TestHelpers/TestHelpers.swift
+++ b/SpaceXAPITests/TestHelpers/TestHelpers.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import SpaceXAPI
+
+/// A partial mock that reports if `.resume()` was called
+class DataTaskMock: URLSessionDataTask {
+    var resumeWasCalled = false
+    override func resume() {
+        resumeWasCalled = true
+    }
+}
+
+/// A network session that allows returning stubbed data
+class SessionMock: NetworkSession {
+    var data: Data?
+    var response: URLResponse?
+    var error: Error?
+    var task: URLSessionDataTask?
+
+    var urlCalled: String?
+
+    func dataTask(with url: URL,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        urlCalled = url.absoluteString
+        completionHandler(data, response, error)
+        return task ?? DataTaskMock()
+    }
+}
+
+/// A stubbed endpoint
+struct EndpointMock: Endpoint {
+    var path: String {
+        return "/test"
+    }
+}

--- a/SpaceXAPITests/TestHelpers/TestHelpers.swift
+++ b/SpaceXAPITests/TestHelpers/TestHelpers.swift
@@ -16,11 +16,11 @@ class SessionMock: NetworkSession {
     var error: Error?
     var task: URLSessionDataTask?
 
-    var urlCalled: String?
+    var calledURL: URL?
 
     func dataTask(with url: URL,
                   completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        urlCalled = url.absoluteString
+        calledURL = url
         completionHandler(data, response, error)
         return task ?? DataTaskMock()
     }

--- a/SpaceXAPITests/TestHelpers/TestHelpers.swift
+++ b/SpaceXAPITests/TestHelpers/TestHelpers.swift
@@ -32,3 +32,8 @@ struct EndpointMock: Endpoint {
         return "/test"
     }
 }
+
+/// A stubbed error
+enum ErrorMock: Error {
+    case expected
+}

--- a/SpaceXAPITests/TestHelpers/XCTestCase+assert.swift
+++ b/SpaceXAPITests/TestHelpers/XCTestCase+assert.swift
@@ -1,0 +1,47 @@
+import SpaceXAPI
+import XCTest
+
+// Add a couple of functions to help checking Result types
+extension XCTestCase {
+    /// Assert that a result has expected data
+    ///
+    /// - Parameters:
+    ///   - result: The Result case to check
+    ///   - expectedData: The expected data
+    func assert<T: Equatable>(_ result: Result<T>?,
+                              containsData expectedData: T,
+                              in file: StaticString = #file,
+                              line: UInt = #line) {
+        switch result {
+        case .success(let data)?:
+            XCTAssertEqual(data, expectedData, file: file, line: line)
+        case .error?:
+            XCTFail("Error was thrown", file: file, line: line)
+        case nil:
+            XCTFail("Result was nil", file: file, line: line)
+        }
+    }
+
+    /// Assert that a result has an expected error
+    ///
+    /// - Parameters:
+    ///   - result: The Result case to check
+    ///   - expectedError: The expected Error
+    func assert<T>(_ result: Result<T>?,
+                   containsError expectedError: Error,
+                   in file: StaticString = #file,
+                   line: UInt = #line) {
+        switch result {
+        case .error(let error)?:
+            XCTAssertEqual(
+                error.localizedDescription,
+                expectedError.localizedDescription,
+                file: file, line: line
+            )
+        case .success?:
+            XCTFail("No error thrown", file: file, line: line)
+        case nil:
+            XCTFail("Result was nil", file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a network wrapper for the SpaceX API.

- [x] Add `SpaceXAPI` struct
- [x] Test URL is created
- [x] Test URL is created with parameters
- [x] Test task is returned
- [x] Test task is resumed
- [x] Test returns server error
- [x] Test returns unknown http response
- [x] Test returns status code if outside of 200–299
- [x] Test returns error if no data
- [x] Test returns data
- [x] Add parameter builder

When complete, this closes #6 