### PR TITLE
Disable swiftlint nesting rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+disabled_rules:
+  - nesting
+
 opt_in_rules:
   - closure_spacing
   - convenience_type

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,3 @@
-disabled_rules:
-  - nesting
-
 opt_in_rules:
   - closure_spacing
   - convenience_type
@@ -16,6 +13,9 @@ opt_in_rules:
 type_body_length:
   warning: 300
   error: 400
+
+nesting:
+  type_level: 3
 
 identifier_name:
   excluded:

--- a/RocketFan/App/Models/Dragon.swift
+++ b/RocketFan/App/Models/Dragon.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable nesting
-
 import Foundation
 
 struct Dragon: Decodable {

--- a/RocketFan/App/Models/Launch.swift
+++ b/RocketFan/App/Models/Launch.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable nesting
-
 import Foundation
 
 struct Launch: Decodable {

--- a/RocketFan/App/Models/Payload.swift
+++ b/RocketFan/App/Models/Payload.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable nesting
-
 import Foundation
 
 struct Payload: Decodable {

--- a/RocketFan/App/Models/Rocket.swift
+++ b/RocketFan/App/Models/Rocket.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable nesting
-
 import Foundation
 
 struct Rocket: Decodable {


### PR DESCRIPTION
As referenced in #21, we will allow 3 levels of nesting before warnings.

This is because sometimes it makes sense to nest:
 
```swift
struct Launch {
  struct Fairings {
    enum Keys: String, CodingKey {
    }
  }
}
```   

`Fairings` makes no sense outside of `Launch`, so it is right to be nested, and so shouldn't present a warning.