### PR TITLE
Compare SpaceXAPITests query items using Sets

### DIFF
--- a/SpaceXAPITests/SpaceXAPITests.swift
+++ b/SpaceXAPITests/SpaceXAPITests.swift
@@ -38,7 +38,7 @@ class SpaceXAPITests: XCTestCase {
 
         // Query item order isn't guaranteed, so don't try and match an absolute string
         let components = URLComponents(url: sessionMock.calledURL!, resolvingAgainstBaseURL: false)!
-        XCTAssertEqual(components.queryItems, options.queryItems)
+        XCTAssertEqual(Set(components.queryItems ?? []), Set(options.queryItems))
     }
 
     func test_SpaceXAPI_ReturnsTask() {


### PR DESCRIPTION
I've been getting a few test failures because URLQueryItems weren't in
the same order. A quick fix for this is create a Set from the array then
compare the sets rather than the arrays.