### PR TITLE
Stop codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: off
 ignore:
 - "RocketFanTests/**/*"
 - "RocketFanUITests/**/*"


### PR DESCRIPTION
For now, `codecov` bot is just adding noise to the comments. Lets disable it for now.