### PR TITLE
Add YouTubeViewController

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		0EBF1B27223C480100194F5D /* Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBF1B26223C480100194F5D /* Landing.swift */; };
 		0EBF2F9E22416758002742B8 /* Launch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBF2F9D22416758002742B8 /* Launch.swift */; };
 		0EBF2FA022416768002742B8 /* LaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBF2F9F22416768002742B8 /* LaunchTests.swift */; };
+		0EEADB7F228866ED00E40712 /* YouTubeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEADB7D228866ED00E40712 /* YouTubeViewController.swift */; };
+		0EEADB80228866ED00E40712 /* YouTubeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0EEADB7E228866ED00E40712 /* YouTubeViewController.xib */; };
+		0EEADBC5228870EC00E40712 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EEADBC4228870EC00E40712 /* WebKit.framework */; };
 		0EEBE92E227B715400B79771 /* LaunchCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0EEBE92C227B715400B79771 /* LaunchCell.xib */; };
 		0EEBE92F227B715400B79771 /* LaunchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEBE92D227B715400B79771 /* LaunchCell.swift */; };
 		0EFA71D3223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFA71D2223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift */; };
@@ -210,6 +213,9 @@
 		0EBF2F9D22416758002742B8 /* Launch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch.swift; sourceTree = "<group>"; };
 		0EBF2F9F22416768002742B8 /* LaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTests.swift; sourceTree = "<group>"; };
 		0ED556972235130E0039BC44 /* User.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = User.xcconfig; sourceTree = "<group>"; };
+		0EEADB7D228866ED00E40712 /* YouTubeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeViewController.swift; sourceTree = "<group>"; };
+		0EEADB7E228866ED00E40712 /* YouTubeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = YouTubeViewController.xib; sourceTree = "<group>"; };
+		0EEADBC4228870EC00E40712 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		0EEBE92C227B715400B79771 /* LaunchCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchCell.xib; sourceTree = "<group>"; };
 		0EEBE92D227B715400B79771 /* LaunchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchCell.swift; sourceTree = "<group>"; };
 		0EFA71D2223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
@@ -300,6 +306,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0EEADBC5228870EC00E40712 /* WebKit.framework in Frameworks */,
 				E1755411223555BA0033C136 /* SpaceXAPI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -362,6 +369,7 @@
 				E17553FD223555BA0033C136 /* SpaceXAPI */,
 				E175540A223555BA0033C136 /* SpaceXAPITests */,
 				0EBCA1A522330CF500E8903F /* Products */,
+				0EEADBC3228870EC00E40712 /* Frameworks */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -452,6 +460,23 @@
 			path = Config;
 			sourceTree = SOURCE_ROOT;
 		};
+		0EEADB78228861DC00E40712 /* Details */ = {
+			isa = PBXGroup;
+			children = (
+				0EEADB7D228866ED00E40712 /* YouTubeViewController.swift */,
+				0EEADB7E228866ED00E40712 /* YouTubeViewController.xib */,
+			);
+			path = Details;
+			sourceTree = "<group>";
+		};
+		0EEADBC3228870EC00E40712 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0EEADBC4228870EC00E40712 /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E11C1D4922702ACA004C3972 /* Feature */ = {
 			isa = PBXGroup;
 			children = (
@@ -491,6 +516,7 @@
 			isa = PBXGroup;
 			children = (
 				E17B0F1A2270EBA0002B550A /* All */,
+				0EEADB78228861DC00E40712 /* Details */,
 				E18600DC227631DF00B0C856 /* Shared */,
 			);
 			path = Launches;
@@ -866,6 +892,7 @@
 				E1FFA025223A993B0056BA6B /* ship.json in Resources */,
 				0EEBE92E227B715400B79771 /* LaunchCell.xib in Resources */,
 				E13B0C0B223E529F000E3E85 /* company.json in Resources */,
+				0EEADB80228866ED00E40712 /* YouTubeViewController.xib in Resources */,
 				E1FFA024223A993B0056BA6B /* core.json in Resources */,
 				E1FFA026223A993B0056BA6B /* history.json in Resources */,
 				E13B0C11223E629A000E3E85 /* launchpad.json in Resources */,
@@ -935,6 +962,7 @@
 			files = (
 				E13BA2592260D4720068DF72 /* DependencyContainer.swift in Sources */,
 				0EBF1B27223C480100194F5D /* Landing.swift in Sources */,
+				0EEADB7F228866ED00E40712 /* YouTubeViewController.swift in Sources */,
 				E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */,
 				0E2B86CB223B02F9005686BB /* History.swift in Sources */,
 				E17B0F1C2270EBBC002B550A /* LaunchesViewController.swift in Sources */,

--- a/RocketFan/Feature/Launches/Details/YouTubeViewController.swift
+++ b/RocketFan/Feature/Launches/Details/YouTubeViewController.swift
@@ -2,12 +2,24 @@ import UIKit
 import WebKit
 
 class YouTubeViewController: UIViewController {
-    init(videoIdentifier: String) {
+    @IBOutlet weak var webView: WKWebView!
+
+    private let videoURL: URL
+
+    init(videoURL: URL) {
+        self.videoURL = videoURL
+
         super.init(nibName: nil, bundle: nil)
     }
 
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        webView.load(URLRequest(url: videoURL))
     }
 }

--- a/RocketFan/Feature/Launches/Details/YouTubeViewController.swift
+++ b/RocketFan/Feature/Launches/Details/YouTubeViewController.swift
@@ -1,0 +1,13 @@
+import UIKit
+import WebKit
+
+class YouTubeViewController: UIViewController {
+    init(videoIdentifier: String) {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/RocketFan/Feature/Launches/Details/YouTubeViewController.xib
+++ b/RocketFan/Feature/Launches/Details/YouTubeViewController.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YouTubeViewController" customModule="RocketFan" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="560" height="315"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p0B-1n-nDh">
+                    <rect key="frame" x="0.0" y="0.0" width="560" height="315"/>
+                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="p0B-1n-nDh" secondAttribute="height" multiplier="1.77:1" priority="750" id="Upv-iZ-bZZ"/>
+                    </constraints>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="p0B-1n-nDh" secondAttribute="trailing" id="JC9-ZU-fbu"/>
+                <constraint firstAttribute="bottom" secondItem="p0B-1n-nDh" secondAttribute="bottom" id="OVr-yD-lkB"/>
+                <constraint firstItem="p0B-1n-nDh" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="a3w-Ov-M7U"/>
+                <constraint firstAttribute="leading" secondItem="p0B-1n-nDh" secondAttribute="leading" id="oNh-kQ-c5f"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="181" y="-280"/>
+        </view>
+    </objects>
+</document>

--- a/RocketFan/Feature/Launches/Details/YouTubeViewController.xib
+++ b/RocketFan/Feature/Launches/Details/YouTubeViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YouTubeViewController" customModule="RocketFan" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="webView" destination="p0B-1n-nDh" id="6qg-yV-Nx5"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -19,9 +20,15 @@
             <rect key="frame" x="0.0" y="0.0" width="560" height="315"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p0B-1n-nDh">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading video" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o37-yG-CYG">
+                    <rect key="frame" x="20" y="148.5" width="520" height="18"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <wkWebView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p0B-1n-nDh">
                     <rect key="frame" x="0.0" y="0.0" width="560" height="315"/>
-                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="p0B-1n-nDh" secondAttribute="height" multiplier="1.77:1" priority="750" id="Upv-iZ-bZZ"/>
                     </constraints>
@@ -31,12 +38,15 @@
                     </wkWebViewConfiguration>
                 </wkWebView>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="o37-yG-CYG" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" symbolic="YES" id="2c8-LE-alx"/>
+                <constraint firstAttribute="trailing" secondItem="o37-yG-CYG" secondAttribute="trailing" priority="250" constant="20" symbolic="YES" id="6ct-Gg-Gnm"/>
+                <constraint firstItem="o37-yG-CYG" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Ato-6T-Gu2"/>
                 <constraint firstAttribute="trailing" secondItem="p0B-1n-nDh" secondAttribute="trailing" id="JC9-ZU-fbu"/>
                 <constraint firstAttribute="bottom" secondItem="p0B-1n-nDh" secondAttribute="bottom" id="OVr-yD-lkB"/>
                 <constraint firstItem="p0B-1n-nDh" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="a3w-Ov-M7U"/>
                 <constraint firstAttribute="leading" secondItem="p0B-1n-nDh" secondAttribute="leading" id="oNh-kQ-c5f"/>
+                <constraint firstItem="o37-yG-CYG" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="q4X-PG-4kD"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
As discussed in #48 we need a View Controller which allows loading in YouTube embed URLs.

### Other approaches considered

I did initially consider simply passing in the YouTube video identifier, allowing the View Controller to create the URL and request before loading. However as `URL(string:)` is failable, I think it would be better to have the parent VC only create this VC if the URL can be created.

We could scrap the .xib, and setup the view in code, as there is fairly trivial subviews in use here. It would also enable easier testing. Speaking of...

### Testing

I can't think of a way to test this right now. I tried replacing the Web View, but couldn't think of a way to inject this before loading the request in `viewDidLoad`.