### PR TITLE
Create a model initialiser helper file

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -20,10 +20,10 @@
 		0E2B86D5223B1089005686BB /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2B86D4223B1089005686BB /* Location.swift */; };
 		0E611C11223312BE00F85DAB /* RocketFanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C10223312BE00F85DAB /* RocketFanTests.swift */; };
 		0E611C13223312C800F85DAB /* RocketFanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C12223312C800F85DAB /* RocketFanUITests.swift */; };
-		0E69A6DD2292B55F008DAFB6 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6DC2292B55F008DAFB6 /* DateFormatter+Extensions.swift */; };
-		0E69A6E02292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6DF2292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift */; };
 		0E69A6D9229291B8008DAFB6 /* LaunchDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6D8229291B8008DAFB6 /* LaunchDetailsViewModel.swift */; };
 		0E69A6DB229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6DA229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift */; };
+		0E69A6DD2292B55F008DAFB6 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6DC2292B55F008DAFB6 /* DateFormatter+Extensions.swift */; };
+		0E69A6E02292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6DF2292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift */; };
 		0E7B8CB5223D9D670036670F /* Dragon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7B8CB4223D9D670036670F /* Dragon.swift */; };
 		0E7B8CB7223D9D7F0036670F /* DragonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7B8CB6223D9D7F0036670F /* DragonTests.swift */; };
 		0E8AF223223AF0B200FB3369 /* MissionFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8AF222223AF0B200FB3369 /* MissionFragment.swift */; };
@@ -45,6 +45,7 @@
 		0EEADBC5228870EC00E40712 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EEADBC4228870EC00E40712 /* WebKit.framework */; };
 		0EEBE92E227B715400B79771 /* LaunchCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0EEBE92C227B715400B79771 /* LaunchCell.xib */; };
 		0EEBE92F227B715400B79771 /* LaunchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEBE92D227B715400B79771 /* LaunchCell.swift */; };
+		0EF7291922959B5D00632563 /* ModelInitialisers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF7291822959B5C00632563 /* ModelInitialisers.swift */; };
 		0EFA71D3223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFA71D2223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift */; };
 		E11C1D48227029E4004C3972 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11C1D47227029E4004C3972 /* UIViewController+Extensions.swift */; };
 		E11C1D4D22702AED004C3972 /* ContentStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11C1D4C22702AED004C3972 /* ContentStateViewController.swift */; };
@@ -194,10 +195,10 @@
 		0E2EA408223519D600A7D350 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		0E611C10223312BE00F85DAB /* RocketFanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanTests.swift; sourceTree = "<group>"; };
 		0E611C12223312C800F85DAB /* RocketFanUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanUITests.swift; sourceTree = "<group>"; };
-		0E69A6DC2292B55F008DAFB6 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
-		0E69A6DF2292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterExtensionsTests.swift; sourceTree = "<group>"; };
 		0E69A6D8229291B8008DAFB6 /* LaunchDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDetailsViewModel.swift; sourceTree = "<group>"; };
 		0E69A6DA229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDetailsViewModelTests.swift; sourceTree = "<group>"; };
+		0E69A6DC2292B55F008DAFB6 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
+		0E69A6DF2292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterExtensionsTests.swift; sourceTree = "<group>"; };
 		0E7B8CB4223D9D670036670F /* Dragon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dragon.swift; sourceTree = "<group>"; };
 		0E7B8CB6223D9D7F0036670F /* DragonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragonTests.swift; sourceTree = "<group>"; };
 		0E8AF222223AF0B200FB3369 /* MissionFragment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissionFragment.swift; sourceTree = "<group>"; };
@@ -226,6 +227,7 @@
 		0EEADBC4228870EC00E40712 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		0EEBE92C227B715400B79771 /* LaunchCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchCell.xib; sourceTree = "<group>"; };
 		0EEBE92D227B715400B79771 /* LaunchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchCell.swift; sourceTree = "<group>"; };
+		0EF7291822959B5C00632563 /* ModelInitialisers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelInitialisers.swift; sourceTree = "<group>"; };
 		0EFA71D2223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
 		E11C1D47227029E4004C3972 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		E11C1D4C22702AED004C3972 /* ContentStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentStateViewController.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 		0EBCA1BB22330CF600E8903F /* RocketFanTests */ = {
 			isa = PBXGroup;
 			children = (
+				0EF7291722959B4C00632563 /* Helpers */,
 				0E69A6DE2292BEC3008DAFB6 /* Extensions */,
 				0EC36A52228CB6A9009B4059 /* Feature */,
 				0EBCA1BE22330CF600E8903F /* Info.plist */,
@@ -510,6 +513,14 @@
 				0EEADBC4228870EC00E40712 /* WebKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		0EF7291722959B4C00632563 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				0EF7291822959B5C00632563 /* ModelInitialisers.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		E11C1D4922702ACA004C3972 /* Feature */ = {
@@ -1046,6 +1057,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1BA53C32242DC1A00601E5C /* RocketTests.swift in Sources */,
+				0EF7291922959B5D00632563 /* ModelInitialisers.swift in Sources */,
 				E1FFA035223AA37E0056BA6B /* CapsuleTests.swift in Sources */,
 				E1F34C52223CDFE600F22086 /* MissionTests.swift in Sources */,
 				0E2A2993225E764000A12243 /* SettingsTests.swift in Sources */,

--- a/RocketFan/App/Models/Launch.swift
+++ b/RocketFan/App/Models/Launch.swift
@@ -106,18 +106,6 @@ extension Launch {
             case type = "rocket_type"
         }
 
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            fairings = try container.decodeIfPresent(Fairings.self, forKey: .fairings)
-            id = try container.decode(String.self, forKey: .id)
-            name = try container.decode(String.self, forKey: .name)
-            secondStage = try container.decode(SecondStage.self, forKey: .secondStage)
-            type = try container.decode(String.self, forKey: .type)
-
-            let firstStageContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .firstStage)
-            firstStage = try firstStageContainer.decode([Core].self, forKey: .cores)
-        }
-
         struct Fairings: Decodable {
             let recovered: Bool?
             let recoveryAttempt: Bool?
@@ -162,5 +150,19 @@ extension Launch {
             let block: Int?
             let payloads: [Payload]
         }
+    }
+}
+
+extension Launch.Rocket {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        fairings = try container.decodeIfPresent(Fairings.self, forKey: .fairings)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        secondStage = try container.decode(SecondStage.self, forKey: .secondStage)
+        type = try container.decode(String.self, forKey: .type)
+
+        let firstStageContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .firstStage)
+        firstStage = try firstStageContainer.decode([Core].self, forKey: .cores)
     }
 }

--- a/RocketFanTests/Helpers/ModelInitialisers.swift
+++ b/RocketFanTests/Helpers/ModelInitialisers.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import RocketFan
+
+/// A collection of custom initialisers that make writing tests easier!
+
+extension Launch {
+    init(details: String? = nil,
+         failureDetails: FailureDetails? = nil,
+         flightClub: URL? = nil,
+         flightNumber: Int = 0,
+         isTentative: Bool = false,
+         launchDate: Date? = nil,
+         launchWindow: Int? = nil,
+         links: Links = Links(),
+         missionId: [String] = [],
+         missionName: String = "",
+         rocket: Rocket = Rocket(),
+         ships: [String] = [],
+         site: Site = Site(),
+         staticFireDate: Date? = nil,
+         tentativeMaxPrecision: String = "",
+         timeline: [String: Int?]? = nil) {
+
+        self.details = details
+        self.failureDetails = failureDetails
+        self.flightClub = flightClub
+        self.flightNumber = flightNumber
+        self.isTentative = isTentative
+        self.launchDate = launchDate
+        self.launchWindow = launchWindow
+        self.links = links
+        self.missionId = missionId
+        self.missionName = missionName
+        self.rocket = rocket
+        self.ships = ships
+        self.site = site
+        self.staticFireDate = staticFireDate
+        self.tentativeMaxPrecision = tentativeMaxPrecision
+        self.timeline = timeline
+    }
+}
+
+extension Launch.Rocket {
+    init() {
+        self.init(fairings: nil, firstStage: [], id: "", name: "", secondStage: SecondStage(), type: "")
+    }
+}
+
+extension Launch.Rocket.SecondStage {
+    init() {
+        self.init(block: nil, payloads: [])
+    }
+}
+
+extension Launch.Site {
+    init() {
+        self.init(id: "", shortName: "")
+    }
+}


### PR DESCRIPTION
This makes creating models easier in unit tests. A few interesting things here:

- The giant Launch initialiser should be unnecessary in Swift 5.1
- Had to move the `Launch.Rocket.init(from decoder)` method into an extension in order to access the default memberwise initialiser