### PR TITLE
Feature/launches

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		E16820102236CDC100E1EDDB /* Roadster.swift in Sources */ = {isa = PBXBuildFile; fileRef = E168200F2236CDC100E1EDDB /* Roadster.swift */; };
 		E16820122236CE6D00E1EDDB /* ShipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16820112236CE6D00E1EDDB /* ShipsTests.swift */; };
 		E16820152236CEDB00E1EDDB /* Ships.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16820132236CEB000E1EDDB /* Ships.swift */; };
+		E173194922959CFD0006EB2D /* LaunchTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173194722959CFD0006EB2D /* LaunchTableViewController.swift */; };
+		E173194A22959CFD0006EB2D /* LaunchTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E173194822959CFD0006EB2D /* LaunchTableViewController.xib */; };
+		E173194C22959D530006EB2D /* LaunchTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */; };
 		E1755405223555BA0033C136 /* SpaceXAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E17553FC223555BA0033C136 /* SpaceXAPI.framework */; };
 		E175540C223555BA0033C136 /* SpaceXAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E175540B223555BA0033C136 /* SpaceXAPITests.swift */; };
 		E1755411223555BA0033C136 /* SpaceXAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E17553FC223555BA0033C136 /* SpaceXAPI.framework */; };
@@ -268,6 +271,9 @@
 		E168200F2236CDC100E1EDDB /* Roadster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roadster.swift; sourceTree = "<group>"; };
 		E16820112236CE6D00E1EDDB /* ShipsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipsTests.swift; sourceTree = "<group>"; };
 		E16820132236CEB000E1EDDB /* Ships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ships.swift; sourceTree = "<group>"; };
+		E173194722959CFD0006EB2D /* LaunchTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTableViewController.swift; sourceTree = "<group>"; };
+		E173194822959CFD0006EB2D /* LaunchTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LaunchTableViewController.xib; sourceTree = "<group>"; };
+		E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTableViewDataSource.swift; sourceTree = "<group>"; };
 		E17553FC223555BA0033C136 /* SpaceXAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SpaceXAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E17553FF223555BA0033C136 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E1755404223555BA0033C136 /* SpaceXAPITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpaceXAPITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -659,6 +665,9 @@
 				0EEBE92D227B715400B79771 /* LaunchCell.swift */,
 				0EEBE92C227B715400B79771 /* LaunchCell.xib */,
 				E17B0F1B2270EBBC002B550A /* LaunchesViewController.swift */,
+				E173194722959CFD0006EB2D /* LaunchTableViewController.swift */,
+				E173194822959CFD0006EB2D /* LaunchTableViewController.xib */,
+				E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */,
 			);
 			path = All;
 			sourceTree = "<group>";
@@ -940,6 +949,7 @@
 				E1F34C58223D0B0500F22086 /* roadster.json in Resources */,
 				E13B0C09223E5166000E3E85 /* apiinfo.json in Resources */,
 				E1FFA025223A993B0056BA6B /* ship.json in Resources */,
+				E173194A22959CFD0006EB2D /* LaunchTableViewController.xib in Resources */,
 				0EEBE92E227B715400B79771 /* LaunchCell.xib in Resources */,
 				E13B0C0B223E529F000E3E85 /* company.json in Resources */,
 				0EEADB80228866ED00E40712 /* YouTubeViewController.xib in Resources */,
@@ -1010,6 +1020,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E173194C22959D530006EB2D /* LaunchTableViewDataSource.swift in Sources */,
 				E13BA2592260D4720068DF72 /* DependencyContainer.swift in Sources */,
 				0EBF1B27223C480100194F5D /* Landing.swift in Sources */,
 				0EEADB7F228866ED00E40712 /* YouTubeViewController.swift in Sources */,
@@ -1038,6 +1049,7 @@
 				E1F34C60223D4B2200F22086 /* Units.swift in Sources */,
 				0E69A6D9229291B8008DAFB6 /* LaunchDetailsViewModel.swift in Sources */,
 				E11C1D5122702DB3004C3972 /* LoadingViewController.swift in Sources */,
+				E173194922959CFD0006EB2D /* LaunchTableViewController.swift in Sources */,
 				0E2B86C5223AF64A005686BB /* Core.swift in Sources */,
 				0E69A6DD2292B55F008DAFB6 /* DateFormatter+Extensions.swift in Sources */,
 				E1F34C5A223D0B3D00F22086 /* Roadster.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		E18600E22276365400B0C856 /* LaunchesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18600E12276365400B0C856 /* LaunchesRepository.swift */; };
 		E18600E42276372C00B0C856 /* LaunchesDependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18600E32276372C00B0C856 /* LaunchesDependencyContainer.swift */; };
 		E18600E62276378F00B0C856 /* LaunchesViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18600E52276378F00B0C856 /* LaunchesViewControllerFactory.swift */; };
+		E18600EA2277408600B0C856 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18600E92277408600B0C856 /* UIView+Extensions.swift */; };
 		E186CCAC223FF55800F77820 /* PayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E186CCAB223FF55800F77820 /* PayloadTests.swift */; };
 		E186CCAF223FF5D400F77820 /* Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E186CCAE223FF5D400F77820 /* Payload.swift */; };
 		E1B1A7BB223FF4E3002A74D8 /* payload.json in Resources */ = {isa = PBXBuildFile; fileRef = E1B1A7BA223FF4E3002A74D8 /* payload.json */; };
@@ -279,6 +280,7 @@
 		E18600E12276365400B0C856 /* LaunchesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesRepository.swift; sourceTree = "<group>"; };
 		E18600E32276372C00B0C856 /* LaunchesDependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesDependencyContainer.swift; sourceTree = "<group>"; };
 		E18600E52276378F00B0C856 /* LaunchesViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesViewControllerFactory.swift; sourceTree = "<group>"; };
+		E18600E92277408600B0C856 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		E186CCAB223FF55800F77820 /* PayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadTests.swift; sourceTree = "<group>"; };
 		E186CCAE223FF5D400F77820 /* Payload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Payload.swift; sourceTree = "<group>"; };
 		E1B1A7BA223FF4E3002A74D8 /* payload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = payload.json; sourceTree = "<group>"; };
@@ -746,6 +748,7 @@
 				0E2B86C8223AFF6C005686BB /* JSONDecoder+Extensions.swift */,
 				0EFA71D2223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift */,
 				E11C1D47227029E4004C3972 /* UIViewController+Extensions.swift */,
+				E18600E92277408600B0C856 /* UIView+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1016,6 +1019,7 @@
 				E18600DE2276321B00B0C856 /* LaunchesCoordinator.swift in Sources */,
 				E1FFA037223AA39C0056BA6B /* Capsule.swift in Sources */,
 				E18600E22276365400B0C856 /* LaunchesRepository.swift in Sources */,
+				E18600EA2277408600B0C856 /* UIView+Extensions.swift in Sources */,
 				E18600DB2276308400B0C856 /* MainTabBarController.swift in Sources */,
 				0E2B86CF223B06A6005686BB /* Links.swift in Sources */,
 				E1BA53C52242DC3E00601E5C /* Rocket.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		E11C1D4D22702AED004C3972 /* ContentStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11C1D4C22702AED004C3972 /* ContentStateViewController.swift */; };
 		E11C1D5122702DB3004C3972 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11C1D4F22702DB3004C3972 /* LoadingViewController.swift */; };
 		E11C1D5222702DB3004C3972 /* LoadingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E11C1D5022702DB3004C3972 /* LoadingViewController.xib */; };
+		E1352AF62296EB5100378732 /* LaunchCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1352AF52296EB5100378732 /* LaunchCellViewModelTests.swift */; };
+		E1352AF82296ED9300378732 /* LaunchCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1352AF72296ED9300378732 /* LaunchCellViewModel.swift */; };
 		E13B0C09223E5166000E3E85 /* apiinfo.json in Resources */ = {isa = PBXBuildFile; fileRef = E13B0C08223E5166000E3E85 /* apiinfo.json */; };
 		E13B0C0B223E529F000E3E85 /* company.json in Resources */ = {isa = PBXBuildFile; fileRef = E13B0C0A223E529F000E3E85 /* company.json */; };
 		E13B0C0D223E5538000E3E85 /* dragon.json in Resources */ = {isa = PBXBuildFile; fileRef = E13B0C0C223E5538000E3E85 /* dragon.json */; };
@@ -238,6 +240,8 @@
 		E11C1D4C22702AED004C3972 /* ContentStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentStateViewController.swift; sourceTree = "<group>"; };
 		E11C1D4F22702DB3004C3972 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		E11C1D5022702DB3004C3972 /* LoadingViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingViewController.xib; sourceTree = "<group>"; };
+		E1352AF52296EB5100378732 /* LaunchCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCellViewModelTests.swift; sourceTree = "<group>"; };
+		E1352AF72296ED9300378732 /* LaunchCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LaunchCellViewModel.swift; path = RocketFan/Feature/Launches/LaunchCellViewModel.swift; sourceTree = SOURCE_ROOT; };
 		E13B0C08223E5166000E3E85 /* apiinfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = apiinfo.json; sourceTree = "<group>"; };
 		E13B0C0A223E529F000E3E85 /* company.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = company.json; sourceTree = "<group>"; };
 		E13B0C0C223E5538000E3E85 /* dragon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = dragon.json; sourceTree = "<group>"; };
@@ -493,6 +497,7 @@
 		0EC36A53228CB6AE009B4059 /* Launches */ = {
 			isa = PBXGroup;
 			children = (
+				E1352AF52296EB5100378732 /* LaunchCellViewModelTests.swift */,
 				0E69A6DA229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift */,
 			);
 			path = Launches;
@@ -667,6 +672,7 @@
 			children = (
 				0EEBE92D227B715400B79771 /* LaunchCell.swift */,
 				0EEBE92C227B715400B79771 /* LaunchCell.xib */,
+				E1352AF72296ED9300378732 /* LaunchCellViewModel.swift */,
 				E17B0F1B2270EBBC002B550A /* LaunchesViewController.swift */,
 				E173194722959CFD0006EB2D /* LaunchTableViewController.swift */,
 				E173194822959CFD0006EB2D /* LaunchTableViewController.xib */,
@@ -1028,6 +1034,7 @@
 				0EBF1B27223C480100194F5D /* Landing.swift in Sources */,
 				0EEADB7F228866ED00E40712 /* YouTubeViewController.swift in Sources */,
 				E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */,
+				E1352AF82296ED9300378732 /* LaunchCellViewModel.swift in Sources */,
 				0E2B86CB223B02F9005686BB /* History.swift in Sources */,
 				E17B0F1C2270EBBC002B550A /* LaunchesViewController.swift in Sources */,
 				E13BA254226061A20068DF72 /* Navigator.swift in Sources */,
@@ -1082,6 +1089,7 @@
 				E1F34C52223CDFE600F22086 /* MissionTests.swift in Sources */,
 				0E2A2993225E764000A12243 /* SettingsTests.swift in Sources */,
 				0E69A6DB229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift in Sources */,
+				E1352AF62296EB5100378732 /* LaunchCellViewModelTests.swift in Sources */,
 				0E7B8CB7223D9D7F0036670F /* DragonTests.swift in Sources */,
 				E1F34C62223D53D500F22086 /* CompanyTests.swift in Sources */,
 				0E2B86C7223AF66E005686BB /* CoreTests.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		E173194922959CFD0006EB2D /* LaunchTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173194722959CFD0006EB2D /* LaunchTableViewController.swift */; };
 		E173194A22959CFD0006EB2D /* LaunchTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E173194822959CFD0006EB2D /* LaunchTableViewController.xib */; };
 		E173194C22959D530006EB2D /* LaunchTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */; };
+		E173194E22959F760006EB2D /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173194D22959F760006EB2D /* Reusable.swift */; };
 		E1755405223555BA0033C136 /* SpaceXAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E17553FC223555BA0033C136 /* SpaceXAPI.framework */; };
 		E175540C223555BA0033C136 /* SpaceXAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E175540B223555BA0033C136 /* SpaceXAPITests.swift */; };
 		E1755411223555BA0033C136 /* SpaceXAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E17553FC223555BA0033C136 /* SpaceXAPI.framework */; };
@@ -274,6 +275,7 @@
 		E173194722959CFD0006EB2D /* LaunchTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTableViewController.swift; sourceTree = "<group>"; };
 		E173194822959CFD0006EB2D /* LaunchTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LaunchTableViewController.xib; sourceTree = "<group>"; };
 		E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTableViewDataSource.swift; sourceTree = "<group>"; };
+		E173194D22959F760006EB2D /* Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reusable.swift; sourceTree = "<group>"; };
 		E17553FC223555BA0033C136 /* SpaceXAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SpaceXAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E17553FF223555BA0033C136 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E1755404223555BA0033C136 /* SpaceXAPITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpaceXAPITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -581,6 +583,7 @@
 			children = (
 				E13BA253226061A20068DF72 /* Navigator.swift */,
 				E13BA255226061C80068DF72 /* ViewControllerFactory.swift */,
+				E173194D22959F760006EB2D /* Reusable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1034,6 +1037,7 @@
 				E1F34C64223D565700F22086 /* Company.swift in Sources */,
 				E1F34C5C223D22D000F22086 /* Speed.swift in Sources */,
 				0EEBE92F227B715400B79771 /* LaunchCell.swift in Sources */,
+				E173194E22959F760006EB2D /* Reusable.swift in Sources */,
 				0E2B86D1223B0E1E005686BB /* LandingPad.swift in Sources */,
 				E1FFA031223A9ADF0056BA6B /* JSONLoader.swift in Sources */,
 				0E2B86C9223AFF6C005686BB /* JSONDecoder+Extensions.swift in Sources */,

--- a/RocketFan/Extensions/UIView+Extensions.swift
+++ b/RocketFan/Extensions/UIView+Extensions.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+extension UIView {
+    func embedSubview(_ subview: UIView) {
+        guard subview.superview != self else { return }
+
+        if subview.superview != nil {
+            subview.removeFromSuperview()
+        }
+
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        subview.frame = bounds
+
+        addSubview(subview)
+
+        NSLayoutConstraint.activate([
+            subview.leadingAnchor.constraint(equalTo: leadingAnchor),
+            trailingAnchor.constraint(equalTo: subview.trailingAnchor),
+
+            subview.topAnchor.constraint(equalTo: topAnchor),
+            bottomAnchor.constraint(equalTo: subview.bottomAnchor)
+            ])
+    }
+
+    func isContainedWithin(_ other: UIView) -> Bool {
+        var current: UIView? = self
+        while let proposedView = current {
+            if proposedView == other { return true }
+            current = proposedView.superview
+        }
+
+        return false
+    }
+}

--- a/RocketFan/Extensions/UIViewController+Extensions.swift
+++ b/RocketFan/Extensions/UIViewController+Extensions.swift
@@ -3,7 +3,8 @@ import UIKit
 extension UIViewController {
     func add(_ child: UIViewController) {
         addChild(child)
-        view.addSubview(child.view)
+
+        view.embedSubview(child.view)
         child.didMove(toParent: self)
     }
 

--- a/RocketFan/Feature/Launches/All/LaunchCell.swift
+++ b/RocketFan/Feature/Launches/All/LaunchCell.swift
@@ -1,9 +1,9 @@
 import UIKit
 
 class LaunchCell: UITableViewCell {
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var dateLabel: UILabel!
-    @IBOutlet weak var launchPadLabel: UILabel!
-    @IBOutlet weak var rocketLabel: UILabel!
-    @IBOutlet weak var patchImageView: UIImageView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var dateLabel: UILabel!
+    @IBOutlet private weak var launchPadLabel: UILabel!
+    @IBOutlet private weak var rocketLabel: UILabel!
+    @IBOutlet private weak var patchImageView: UIImageView!
 }

--- a/RocketFan/Feature/Launches/All/LaunchTableViewController.swift
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewController.swift
@@ -1,0 +1,5 @@
+
+import UIKit
+
+class LaunchTableViewController: UITableViewController {
+}

--- a/RocketFan/Feature/Launches/All/LaunchTableViewController.swift
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewController.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 
 class LaunchTableViewController: UITableViewController {

--- a/RocketFan/Feature/Launches/All/LaunchTableViewController.xib
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewController.xib
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LaunchTableViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vLr-E1-eTs"/>
+            <connections>
+                <outlet property="dataSource" destination="-1" id="Tng-2m-Rnh"/>
+                <outlet property="delegate" destination="-1" id="9aC-8N-iBw"/>
+            </connections>
+        </tableView>
+    </objects>
+</document>

--- a/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
@@ -14,6 +14,7 @@ extension LaunchTableViewDataSource: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
+        let cell = tableView.dequeueReusableCell(for: indexPath, cellType: LaunchCell.self)
+        return cell
     }
 }

--- a/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class LaunchTableViewDataSource: NSObject {
+    private var launches: [Launch]?
+
+    func update(with launches: [Launch]) {
+        self.launches = launches
+    }
+}
+
+extension LaunchTableViewDataSource: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return launches?.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+}

--- a/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
+++ b/RocketFan/Feature/Launches/All/LaunchTableViewDataSource.swift
@@ -14,7 +14,7 @@ extension LaunchTableViewDataSource: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(for: indexPath, cellType: LaunchCell.self)
+        let cell: LaunchCell = tableView.dequeueReusableCell(for: indexPath)
         return cell
     }
 }

--- a/RocketFan/Feature/Launches/All/LaunchesViewController.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewController.swift
@@ -2,11 +2,11 @@ import UIKit
 
 class LaunchesViewController: UIViewController {
     private lazy var contentStateViewController = ContentStateViewController()
-    private let repository: LaunchesRepository
+    private var repository: LaunchesRepository
 
     init(with repository: LaunchesRepository) {
-
         self.repository = repository
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -16,7 +16,28 @@ class LaunchesViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         view.backgroundColor = .white
-        contentStateViewController.transition(to: .loading)
+        add(contentStateViewController)
+        fetchData()
+    }
+}
+
+extension LaunchesViewController {
+    private func fetchData() {
+        repository.allLaunches { [weak self] (result) in
+
+            do {
+                let launches = try result.get()
+                self?.handleSuccess(with: launches)
+
+            } catch {
+                self?.contentStateViewController.transition(to: .failed(error))
+            }
+        }
+    }
+
+    private func handleSuccess(with data: [Launch]) {
+      // Go to LaunchStateVC
     }
 }

--- a/RocketFan/Feature/Launches/LaunchCellViewModel.swift
+++ b/RocketFan/Feature/Launches/LaunchCellViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct LaunchCellViewModel {
+    private let launch: Launch
+    private let dateFormatter: DateFormatter
+
+    init(with launch: Launch,
+         _ dateFormatter: DateFormatter) {
+
+        self.launch = launch
+        self.dateFormatter = dateFormatter
+        self.dateFormatter.setPrecision(.hour)
+    }
+}
+
+extension LaunchCellViewModel {
+    var missionName: String {
+        return launch.missionName
+    }
+
+    var launchDate: String {
+        guard let date = launch.launchDate else { return "TBC" }
+
+        return dateFormatter.string(from: date)
+    }
+
+    var siteShortName: String {
+        return launch.site.shortName
+    }
+
+    var rocketName: String {
+        return launch.rocket.name
+    }
+}

--- a/RocketFan/Feature/Launches/Shared/LaunchesRepository.swift
+++ b/RocketFan/Feature/Launches/Shared/LaunchesRepository.swift
@@ -3,8 +3,32 @@ import SpaceXAPI
 
 struct LaunchesRepository {
     private let api: SpaceXAPI
+    private var sessionTask: URLSessionTask?
 
     init(with api: SpaceXAPI) {
         self.api = api
+    }
+
+    func cancelCurrentTask() {
+        sessionTask?.cancel()
+    }
+}
+
+extension LaunchesRepository {
+    mutating func allLaunches(completion: @escaping (Result<[Launch], Error>) -> Void) {
+        sessionTask = api.get(Launches.all) { (result) in
+            do {
+
+                let data = try result.get()
+                let decoder = JSONDecoder(dateDecodingStrategy: .secondsSince1970)
+                let launches = try decoder.decoded([Launch].self, from: data)
+
+                completion(.success(launches))
+
+            } catch {
+                completion(.failure(error))
+
+            }
+        }
     }
 }

--- a/RocketFan/Feature/Shared/ViewControllers/ContentStateViewController.swift
+++ b/RocketFan/Feature/Shared/ViewControllers/ContentStateViewController.swift
@@ -5,10 +5,20 @@ class ContentStateViewController: UIViewController {
     private var state: State?
     private var shownViewController: UIViewController?
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if state == nil {
+            transition(to: .loading)
+        }
+    }
+
     func transition(to newState: State) {
         shownViewController?.remove()
+
         let controller = viewController(for: newState)
         add(controller)
+
         shownViewController = controller
         state = newState
     }

--- a/RocketFan/Protocols/Reusable.swift
+++ b/RocketFan/Protocols/Reusable.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UIKit
+
+/// A collection of protocols which make registering and dequeueing cells much cleaner
+
+protocol Reusable {
+    static var reuseIdentifier: String { get }
+}
+
+extension UITableViewCell: Reusable {
+    static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}
+
+protocol NibLoadable: class {
+    static var nib: UINib { get }
+}
+
+extension NibLoadable {
+    static var nib: UINib {
+        let name = String(describing: self)
+        let bundle = Bundle(for: self)
+        return UINib(nibName: name, bundle: bundle)
+    }
+}
+
+extension UITableView {
+    func register<T: UITableViewCell>(cellType: T.Type) where T: NibLoadable {
+        print(T.nib, T.reuseIdentifier)
+        register(T.nib, forCellReuseIdentifier: T.reuseIdentifier)
+    }
+
+    func dequeueReusableCell<T: UITableViewCell>(for indexPath: IndexPath, cellType: T.Type = T.self) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
+            fatalError("Unable to dequeue cell with identifier \(T.reuseIdentifier)")
+        }
+
+        return cell
+    }
+}

--- a/RocketFanTests/Feature/Launches/LaunchCellViewModelTests.swift
+++ b/RocketFanTests/Feature/Launches/LaunchCellViewModelTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import RocketFan
+
+class LaunchCellViewModelTests: XCTestCase {
+    var sut: LaunchCellViewModel?
+    var launch: Launch?
+    var dateFormatter: DateFormatter?
+
+    override func setUp() {
+        dateFormatter = getDateFormatter()
+        launch = getLaunch()
+
+        sut = LaunchCellViewModel(with: launch!, dateFormatter!)
+    }
+
+    override func tearDown() {
+        sut = nil
+        launch = nil
+    }
+
+    func test_GivenLaunch_ReturnsMissionName() {
+        XCTAssertEqual(sut?.missionName, launch?.missionName)
+    }
+
+    func test_GivenLaunch_ReturnsFormattedLaunchDate() {
+        XCTAssertEqual(sut?.launchDate, "01 Sep 2020, 00:00:00")
+    }
+
+    func test_GivenLaunch_ReturnsSiteShortName() {
+        XCTAssertEqual(sut?.siteShortName, launch?.site.shortName)
+    }
+
+    func test_GivenLaunch_ReturnsRocketName() {
+        XCTAssertEqual(sut?.rocketName, launch?.rocket.name)
+    }
+
+    func test_GivenLaunchWithNoDate_ReturnsTBC() {
+        let launch = getLaunchWithNoDate()
+
+        sut = LaunchCellViewModel(with: launch, dateFormatter!)
+
+        XCTAssertEqual(sut?.launchDate, "TBC")
+    }
+}
+
+extension LaunchCellViewModelTests {
+    private func getLaunch() -> Launch {
+        return Launch(missionName: "GPS SV05",
+                      launchDate: launchDate()!,
+                      site: launchSite(),
+                      rocket: rocket())
+    }
+
+    private func getLaunchWithNoDate() -> Launch {
+        return Launch(missionName: "GPS SV05",
+                      site: launchSite(),
+                      rocket: rocket())
+    }
+
+    func launchDate() -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions =  [.withInternetDateTime, .withFractionalSeconds]
+
+        return formatter.date(from: "2020-09-01T00:00:00.000Z")
+    }
+
+    private func getDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+
+        formatter.locale = Locale(identifier: "en_GB")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.setPrecision(.hour)
+
+        return formatter
+    }
+
+    private func launchSite() -> Launch.Site {
+        return Launch.Site(shortName: "CCAFS SLC 40")
+    }
+
+    private func rocket() -> Launch.Rocket {
+        return Launch.Rocket(name: "Falcon 9")
+    }
+}

--- a/RocketFanTests/Feature/Launches/LaunchCellViewModelTests.swift
+++ b/RocketFanTests/Feature/Launches/LaunchCellViewModelTests.swift
@@ -46,16 +46,16 @@ class LaunchCellViewModelTests: XCTestCase {
 
 extension LaunchCellViewModelTests {
     private func getLaunch() -> Launch {
-        return Launch(missionName: "GPS SV05",
-                      launchDate: launchDate()!,
-                      site: launchSite(),
-                      rocket: rocket())
+        return Launch(launchDate: launchDate()!,
+                      missionName: "GPS SV05",
+                      rocket: rocket(),
+                      site: launchSite())
     }
 
     private func getLaunchWithNoDate() -> Launch {
         return Launch(missionName: "GPS SV05",
-                      site: launchSite(),
-                      rocket: rocket())
+                      rocket: rocket(),
+                      site: launchSite())
     }
 
     func launchDate() -> Date? {

--- a/RocketFanTests/Helpers/ModelInitialisers.swift
+++ b/RocketFanTests/Helpers/ModelInitialisers.swift
@@ -40,25 +40,6 @@ extension Launch {
     }
 }
 
-extension Launch {
-    init(missionName: String,
-         launchDate: Date? = nil,
-         site: Site,
-         rocket: Rocket) {
-
-        self.init(flightNumber: 0,
-                  isTentative: false,
-                  launchDate: launchDate,
-                  links: Links(),
-                  missionId: [],
-                  missionName: missionName,
-                  rocket: rocket,
-                  ships: [],
-                  site: site,
-                  tentativeMaxPrecision: "")
-    }
-}
-
 extension Launch.Rocket {
     init() {
         self.init(fairings: nil, firstStage: [], id: "", name: "", secondStage: SecondStage(), type: "")

--- a/RocketFanTests/Helpers/ModelInitialisers.swift
+++ b/RocketFanTests/Helpers/ModelInitialisers.swift
@@ -40,9 +40,38 @@ extension Launch {
     }
 }
 
+extension Launch {
+    init(missionName: String,
+         launchDate: Date? = nil,
+         site: Site,
+         rocket: Rocket) {
+
+        self.init(flightNumber: 0,
+                  isTentative: false,
+                  launchDate: launchDate,
+                  links: Links(),
+                  missionId: [],
+                  missionName: missionName,
+                  rocket: rocket,
+                  ships: [],
+                  site: site,
+                  tentativeMaxPrecision: "")
+    }
+}
+
 extension Launch.Rocket {
     init() {
         self.init(fairings: nil, firstStage: [], id: "", name: "", secondStage: SecondStage(), type: "")
+    }
+
+    init(name: String) {
+
+        self.init(fairings: nil,
+                  firstStage: [],
+                  id: "",
+                  name: name,
+                  secondStage: SecondStage(),
+                  type: "")
     }
 }
 
@@ -55,5 +84,9 @@ extension Launch.Rocket.SecondStage {
 extension Launch.Site {
     init() {
         self.init(id: "", shortName: "")
+    }
+
+    init(shortName: String) {
+        self.init(id: "", shortName: shortName)
     }
 }


### PR DESCRIPTION
This PR relates to [#45](https://github.com/RocketFanOrg/RocketFanApp/issues/45)

- Base implementations for the DataSource and TableView
- Added ViewModel for the `LaunchCell` as well as tests
- Added a protocol - `Reusable` - to make registering UITableViewCell's easier
- Added implementation for the launch repo and `LaunchesViewController`
- Added a `UIView` extension to make adding / removing child VC's easier

This PR may be a little big as a few files changed. I promise I will try keep future ones smaller!