### PR TITLE
Added SearchEngine for finding launches and tests

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		E13BA254226061A20068DF72 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA253226061A20068DF72 /* Navigator.swift */; };
 		E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA255226061C80068DF72 /* ViewControllerFactory.swift */; };
 		E13BA2592260D4720068DF72 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA2582260D4720068DF72 /* DependencyContainer.swift */; };
+		E16473A32299928600C67AD9 /* SearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A22299928600C67AD9 /* SearchEngine.swift */; };
+		E16473A5229992C800C67AD9 /* SearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A4229992C800C67AD9 /* SearchEngineTests.swift */; };
 		E1681FE42236ABE800E1EDDB /* Cores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1681FE32236ABE800E1EDDB /* Cores.swift */; };
 		E1681FE62236AC2C00E1EDDB /* CoresTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1681FE52236AC2C00E1EDDB /* CoresTests.swift */; };
 		E1681FE82236AFED00E1EDDB /* DragonsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1681FE72236AFED00E1EDDB /* DragonsTests.swift */; };
@@ -252,6 +254,8 @@
 		E13BA253226061A20068DF72 /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		E13BA255226061C80068DF72 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		E13BA2582260D4720068DF72 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
+		E16473A22299928600C67AD9 /* SearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngine.swift; sourceTree = "<group>"; };
+		E16473A4229992C800C67AD9 /* SearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineTests.swift; sourceTree = "<group>"; };
 		E1681FE32236ABE800E1EDDB /* Cores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cores.swift; sourceTree = "<group>"; };
 		E1681FE52236AC2C00E1EDDB /* CoresTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoresTests.swift; sourceTree = "<group>"; };
 		E1681FE72236AFED00E1EDDB /* DragonsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragonsTests.swift; sourceTree = "<group>"; };
@@ -499,6 +503,7 @@
 			children = (
 				E1352AF52296EB5100378732 /* LaunchCellViewModelTests.swift */,
 				0E69A6DA229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift */,
+				E16473A4229992C800C67AD9 /* SearchEngineTests.swift */,
 			);
 			path = Launches;
 			sourceTree = "<group>";
@@ -677,6 +682,7 @@
 				E173194722959CFD0006EB2D /* LaunchTableViewController.swift */,
 				E173194822959CFD0006EB2D /* LaunchTableViewController.xib */,
 				E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */,
+				E16473A22299928600C67AD9 /* SearchEngine.swift */,
 			);
 			path = All;
 			sourceTree = "<group>";
@@ -1038,6 +1044,7 @@
 				0E2B86CB223B02F9005686BB /* History.swift in Sources */,
 				E17B0F1C2270EBBC002B550A /* LaunchesViewController.swift in Sources */,
 				E13BA254226061A20068DF72 /* Navigator.swift in Sources */,
+				E16473A32299928600C67AD9 /* SearchEngine.swift in Sources */,
 				0E2A2990225E762000A12243 /* Settings.swift in Sources */,
 				0E7B8CB5223D9D670036670F /* Dragon.swift in Sources */,
 				E1FFA03A223AA6320056BA6B /* Codable+Extensions.swift in Sources */,
@@ -1088,6 +1095,7 @@
 				E1FFA035223AA37E0056BA6B /* CapsuleTests.swift in Sources */,
 				E1F34C52223CDFE600F22086 /* MissionTests.swift in Sources */,
 				0E2A2993225E764000A12243 /* SettingsTests.swift in Sources */,
+				E16473A5229992C800C67AD9 /* SearchEngineTests.swift in Sources */,
 				0E69A6DB229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift in Sources */,
 				E1352AF62296EB5100378732 /* LaunchCellViewModelTests.swift in Sources */,
 				0E7B8CB7223D9D7F0036670F /* DragonTests.swift in Sources */,

--- a/RocketFan/Feature/Launches/All/SearchEngine.swift
+++ b/RocketFan/Feature/Launches/All/SearchEngine.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct SearchEngine {
+    private let launches: [Launch]
+
+    init(with launches: [Launch]) {
+        self.launches = launches
+    }
+}
+
+extension SearchEngine {
+    func launches(before date: Date) -> [Launch] {
+        let validLaunches = launches.filter { $0.launchDate != nil }
+        return validLaunches.filter { $0.launchDate! < date }
+    }
+
+    func launches(after date: Date) -> [Launch] {
+        return launches.filter { $0.launchDate == nil || $0.launchDate! >= date }
+    }
+
+    func launchesWhere(missionNameContains searchTerm: String) -> [Launch] {
+        guard searchTerm.isEmpty == false else { return [] } //Should contain at least one character
+
+        return launches.filter { partialMatches($0.missionName, with: searchTerm) }
+    }
+}
+
+extension SearchEngine {
+    private func partialMatches(_ string: String, with stringB: String) -> Bool {
+
+        // lowercased, trim whitespace and newline for better results
+        let firstString = string.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondString = stringB.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return firstString.range(of: secondString) != nil
+    }
+}

--- a/RocketFanTests/Feature/Launches/SearchEngineTests.swift
+++ b/RocketFanTests/Feature/Launches/SearchEngineTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import RocketFan
+
+class SearchEngineTests: XCTestCase {
+    private var sut: SearchEngine?
+
+    override func setUp() {
+        guard let allLaunches = loadLaunchs() else {
+            XCTFail("Couldn't load test data")
+            return
+        }
+
+        sut = SearchEngine(with: allLaunches)
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    func test_GivenReferenceDate_ReturnsPastLaunches() {
+        let date = referenceDate()
+        let launches = sut?.launches(before: date)
+
+        XCTAssertTrue(all(launches!, areBefore: date), "All launches must be before referenceDate")
+    }
+
+    func test_GivenReferenceDate_ReturnsFutureLaunches() {
+        let date = referenceDate()
+        let upcomingLaunches = sut?.launches(after: date)
+
+        XCTAssertTrue(all(upcomingLaunches!, areAfter: date), "All launches must be after referenceDate")
+    }
+
+    func test_GivenEmptySearchTerm_ReturnsEmptyResult() {
+        let launches = sut?.launchesWhere(missionNameContains: "")
+
+        XCTAssertTrue(launches!.isEmpty)
+    }
+
+    func test_GivenIncorrectSearchTerm_ReturnsEmptyResults() {
+        let launches = sut?.launchesWhere(missionNameContains: "99999")
+
+        XCTAssertTrue(launches!.isEmpty, "Should be empty")
+    }
+
+    func test_GivenCompleteSearchTerm_ReturnsOneLaunch() {
+        let launches = sut?.launchesWhere(missionNameContains: "FalconSat")
+
+        XCTAssertTrue(launches!.count == 1, "Should have exactly one result")
+    }
+
+    func test_GivenPartialSearchTerm_ReturnsManyLaunches() {
+        let launches = sut?.launchesWhere(missionNameContains: "Sat")
+
+        XCTAssertTrue(launches!.count > 1, "Should not be empty")
+    }
+
+    func test_GivenValidSearchTermWithSpace_ReturnsNonEmptyResult() {
+        let launches = sut?.launchesWhere(missionNameContains: "Falcon 9")
+
+        XCTAssertFalse(launches!.isEmpty, "Should not be empty")
+    }
+
+    func test_GivenValidSearchTermWithLeadingWithSpace_ReturnsNonEmptyResult() {
+        let launches = sut?.launchesWhere(missionNameContains: "Falcon ")
+
+        XCTAssertFalse(launches!.isEmpty, "Should not be empty")
+    }
+
+    func test_GivenUpperCaseSearchTerm_ReturnsNonEmptyResult() {
+        let launches = sut?.launchesWhere(missionNameContains: "FALCON 9")
+
+        XCTAssertFalse(launches!.isEmpty, "Should not be empty")
+    }
+}
+
+// MARK: - Test Helpers
+extension SearchEngineTests {
+    private func loadLaunchs() -> [Launch]? {
+        let json = JSONLoader.load(.launches)!
+        let decoder = JSONDecoder(dateDecodingStrategy: .secondsSince1970)
+        return try? decoder.decoded([Launch].self, from: json)
+    }
+
+    private func all(_ launaches: [Launch], areBefore date: Date) -> Bool {
+        let todaysDate = Date()
+
+        for launch in launaches {
+            guard let launchDate = launch.launchDate else { return false }
+
+            if launchDate >= todaysDate {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func all(_ launaches: [Launch], areAfter date: Date) -> Bool {
+        let todaysDate = Date()
+
+        for launch in launaches {
+            guard let launchDate = launch.launchDate else { continue }
+
+            if launchDate > todaysDate {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func referenceDate() -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFractionalSeconds]
+
+        return formatter.date(from: "2019-05-25T00:00:00.000Z")!
+    }
+}


### PR DESCRIPTION
This PR relates to [#45](https://github.com/RocketFanOrg/RocketFanApp/issues/45)

- Added a `SearchEngine` that is responsible for finding launches based on either a date or search term

- Added Tests for the engine 

This `SearchEngine` is responsible for providing Launches that are either before to after a specified date as well as finding launches that match part or full mission name search term. 

It will help us with the search UI that is to be implemented with feature 45