### PR TITLE
Added LaunchesViewModel

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -64,6 +64,10 @@
 		E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA255226061C80068DF72 /* ViewControllerFactory.swift */; };
 		E13BA2592260D4720068DF72 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA2582260D4720068DF72 /* DependencyContainer.swift */; };
 		E144752F229C48A7006D1E82 /* LaunchesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E144752E229C48A7006D1E82 /* LaunchesViewModel.swift */; };
+		E1447531229C6093006D1E82 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1447530229C6093006D1E82 /* Repository.swift */; };
+		E1447533229C6246006D1E82 /* LaunchesRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1447532229C6246006D1E82 /* LaunchesRepositoryProtocol.swift */; };
+		E1447536229C6317006D1E82 /* MockLaunchesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1447535229C6317006D1E82 /* MockLaunchesRepository.swift */; };
+		E1447538229C64A7006D1E82 /* LaunchesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1447537229C64A7006D1E82 /* LaunchesViewModelTests.swift */; };
 		E16473A32299928600C67AD9 /* SearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A22299928600C67AD9 /* SearchEngine.swift */; };
 		E16473A5229992C800C67AD9 /* SearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A4229992C800C67AD9 /* SearchEngineTests.swift */; };
 		E1681FE42236ABE800E1EDDB /* Cores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1681FE32236ABE800E1EDDB /* Cores.swift */; };
@@ -256,6 +260,10 @@
 		E13BA255226061C80068DF72 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		E13BA2582260D4720068DF72 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
 		E144752E229C48A7006D1E82 /* LaunchesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesViewModel.swift; sourceTree = "<group>"; };
+		E1447530229C6093006D1E82 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
+		E1447532229C6246006D1E82 /* LaunchesRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesRepositoryProtocol.swift; sourceTree = "<group>"; };
+		E1447535229C6317006D1E82 /* MockLaunchesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchesRepository.swift; sourceTree = "<group>"; };
+		E1447537229C64A7006D1E82 /* LaunchesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesViewModelTests.swift; sourceTree = "<group>"; };
 		E16473A22299928600C67AD9 /* SearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngine.swift; sourceTree = "<group>"; };
 		E16473A4229992C800C67AD9 /* SearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineTests.swift; sourceTree = "<group>"; };
 		E1681FE32236ABE800E1EDDB /* Cores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cores.swift; sourceTree = "<group>"; };
@@ -505,6 +513,8 @@
 			children = (
 				E1352AF52296EB5100378732 /* LaunchCellViewModelTests.swift */,
 				0E69A6DA229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift */,
+				E1447537229C64A7006D1E82 /* LaunchesViewModelTests.swift */,
+				E1447534229C62F3006D1E82 /* Mocks */,
 				E16473A4229992C800C67AD9 /* SearchEngineTests.swift */,
 			);
 			path = Launches;
@@ -596,6 +606,7 @@
 				E13BA253226061A20068DF72 /* Navigator.swift */,
 				E13BA255226061C80068DF72 /* ViewControllerFactory.swift */,
 				E173194D22959F760006EB2D /* Reusable.swift */,
+				E1447530229C6093006D1E82 /* Repository.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -606,6 +617,14 @@
 				E13BA2582260D4720068DF72 /* DependencyContainer.swift */,
 			);
 			path = "Dependency Containers";
+			sourceTree = "<group>";
+		};
+		E1447534229C62F3006D1E82 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				E1447535229C6317006D1E82 /* MockLaunchesRepository.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		E17553FD223555BA0033C136 /* SpaceXAPI */ = {
@@ -696,6 +715,7 @@
 				E18600DD2276321B00B0C856 /* LaunchesCoordinator.swift */,
 				E18600E32276372C00B0C856 /* LaunchesDependencyContainer.swift */,
 				E18600E12276365400B0C856 /* LaunchesRepository.swift */,
+				E1447532229C6246006D1E82 /* LaunchesRepositoryProtocol.swift */,
 				E18600E52276378F00B0C856 /* LaunchesViewControllerFactory.swift */,
 			);
 			path = Shared;
@@ -1045,6 +1065,7 @@
 				E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */,
 				E1352AF82296ED9300378732 /* LaunchCellViewModel.swift in Sources */,
 				0E2B86CB223B02F9005686BB /* History.swift in Sources */,
+				E1447531229C6093006D1E82 /* Repository.swift in Sources */,
 				E17B0F1C2270EBBC002B550A /* LaunchesViewController.swift in Sources */,
 				E13BA254226061A20068DF72 /* Navigator.swift in Sources */,
 				E16473A32299928600C67AD9 /* SearchEngine.swift in Sources */,
@@ -1063,6 +1084,7 @@
 				E1FFA037223AA39C0056BA6B /* Capsule.swift in Sources */,
 				E18600E22276365400B0C856 /* LaunchesRepository.swift in Sources */,
 				E144752F229C48A7006D1E82 /* LaunchesViewModel.swift in Sources */,
+				E1447533229C6246006D1E82 /* LaunchesRepositoryProtocol.swift in Sources */,
 				E18600EA2277408600B0C856 /* UIView+Extensions.swift in Sources */,
 				E18600DB2276308400B0C856 /* MainTabBarController.swift in Sources */,
 				0E2B86CF223B06A6005686BB /* Links.swift in Sources */,
@@ -1099,6 +1121,7 @@
 				E1FFA035223AA37E0056BA6B /* CapsuleTests.swift in Sources */,
 				E1F34C52223CDFE600F22086 /* MissionTests.swift in Sources */,
 				0E2A2993225E764000A12243 /* SettingsTests.swift in Sources */,
+				E1447536229C6317006D1E82 /* MockLaunchesRepository.swift in Sources */,
 				E16473A5229992C800C67AD9 /* SearchEngineTests.swift in Sources */,
 				0E69A6DB229291D4008DAFB6 /* LaunchDetailsViewModelTests.swift in Sources */,
 				E1352AF62296EB5100378732 /* LaunchCellViewModelTests.swift in Sources */,
@@ -1110,6 +1133,7 @@
 				0E2B86CD223B030A005686BB /* HistoryTests.swift in Sources */,
 				0E69A6E02292BEDA008DAFB6 /* DateFormatterExtensionsTests.swift in Sources */,
 				0E2B86D3223B0E30005686BB /* LandingPadTests.swift in Sources */,
+				E1447538229C64A7006D1E82 /* LaunchesViewModelTests.swift in Sources */,
 				0EBF2FA022416768002742B8 /* LaunchTests.swift in Sources */,
 				E1F34C56223CF43100F22086 /* RoadsterTests.swift in Sources */,
 				0E611C11223312BE00F85DAB /* RocketFanTests.swift in Sources */,

--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		E13BA254226061A20068DF72 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA253226061A20068DF72 /* Navigator.swift */; };
 		E13BA256226061C80068DF72 /* ViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA255226061C80068DF72 /* ViewControllerFactory.swift */; };
 		E13BA2592260D4720068DF72 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13BA2582260D4720068DF72 /* DependencyContainer.swift */; };
+		E144752F229C48A7006D1E82 /* LaunchesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E144752E229C48A7006D1E82 /* LaunchesViewModel.swift */; };
 		E16473A32299928600C67AD9 /* SearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A22299928600C67AD9 /* SearchEngine.swift */; };
 		E16473A5229992C800C67AD9 /* SearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16473A4229992C800C67AD9 /* SearchEngineTests.swift */; };
 		E1681FE42236ABE800E1EDDB /* Cores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1681FE32236ABE800E1EDDB /* Cores.swift */; };
@@ -254,6 +255,7 @@
 		E13BA253226061A20068DF72 /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		E13BA255226061C80068DF72 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		E13BA2582260D4720068DF72 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
+		E144752E229C48A7006D1E82 /* LaunchesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchesViewModel.swift; sourceTree = "<group>"; };
 		E16473A22299928600C67AD9 /* SearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngine.swift; sourceTree = "<group>"; };
 		E16473A4229992C800C67AD9 /* SearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineTests.swift; sourceTree = "<group>"; };
 		E1681FE32236ABE800E1EDDB /* Cores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cores.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				0EEBE92C227B715400B79771 /* LaunchCell.xib */,
 				E1352AF72296ED9300378732 /* LaunchCellViewModel.swift */,
 				E17B0F1B2270EBBC002B550A /* LaunchesViewController.swift */,
+				E144752E229C48A7006D1E82 /* LaunchesViewModel.swift */,
 				E173194722959CFD0006EB2D /* LaunchTableViewController.swift */,
 				E173194822959CFD0006EB2D /* LaunchTableViewController.xib */,
 				E173194B22959D530006EB2D /* LaunchTableViewDataSource.swift */,
@@ -1059,6 +1062,7 @@
 				E18600DE2276321B00B0C856 /* LaunchesCoordinator.swift in Sources */,
 				E1FFA037223AA39C0056BA6B /* Capsule.swift in Sources */,
 				E18600E22276365400B0C856 /* LaunchesRepository.swift in Sources */,
+				E144752F229C48A7006D1E82 /* LaunchesViewModel.swift in Sources */,
 				E18600EA2277408600B0C856 /* UIView+Extensions.swift in Sources */,
 				E18600DB2276308400B0C856 /* MainTabBarController.swift in Sources */,
 				0E2B86CF223B06A6005686BB /* Links.swift in Sources */,

--- a/RocketFan/Feature/Launches/All/LaunchesViewController.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewController.swift
@@ -2,10 +2,10 @@ import UIKit
 
 class LaunchesViewController: UIViewController {
     private lazy var contentStateViewController = ContentStateViewController()
-    private var repository: LaunchesRepository
+    private let viewModel: LaunchesViewModel
 
-    init(with repository: LaunchesRepository) {
-        self.repository = repository
+    init(with viewModel: LaunchesViewModel) {
+        self.viewModel = viewModel
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -17,24 +17,16 @@ class LaunchesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = "Launches"
         view.backgroundColor = .white
         add(contentStateViewController)
-        fetchData()
+        bindViewModel()
     }
 }
 
 extension LaunchesViewController {
-    private func fetchData() {
-        repository.allLaunches { [weak self] (result) in
-
-            do {
-                let launches = try result.get()
-                self?.handleSuccess(with: launches)
-
-            } catch {
-                self?.contentStateViewController.transition(to: .failed(error))
-            }
+    private func bindViewModel() {
+        viewModel.launchesUpdated = { [weak self] launches in
+            self?.handleSuccess(with: launches)
         }
     }
 

--- a/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
@@ -1,14 +1,15 @@
 import Foundation
 
 class LaunchesViewModel {
-    private var repository: LaunchesRepository?
+    private var repository: LaunchesRepositoryProtocol?
+    private var searchEngine: SearchEngine?
 
     var modelError: ((_ error: Error) -> Void)?
     var launchesUpdated: ((_ launches: [Launch]) -> Void)? {
         didSet { fetchAllLaunches() }
     }
 
-    init(with repo: LaunchesRepository) {
+    init(with repo: LaunchesRepositoryProtocol) {
         repository = repo
     }
 }
@@ -19,11 +20,19 @@ extension LaunchesViewModel {
 
             do {
                 let launches = try result.get()
-                self?.launchesUpdated?(launches)
+                self?.searchEngine = SearchEngine(with: launches)
+                self?.loadPastLaunches()
 
             } catch {
-
+                self?.modelError?(error)
             }
         }
+    }
+
+    private func loadPastLaunches() {
+        let currentDate = Date()
+        guard let pastLaunches = searchEngine?.launches(before: currentDate) else { return }
+
+        launchesUpdated?(pastLaunches)
     }
 }

--- a/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
@@ -1,4 +1,29 @@
 import Foundation
 
-struct LaunchesViewModel {
+class LaunchesViewModel {
+    private var repository: LaunchesRepository?
+
+    var modelError: ((_ error: Error) -> Void)?
+    var launchesUpdated: ((_ launches: [Launch]) -> Void)? {
+        didSet { fetchAllLaunches() }
+    }
+
+    init(with repo: LaunchesRepository) {
+        repository = repo
+    }
+}
+
+extension LaunchesViewModel {
+    private func fetchAllLaunches() {
+        repository?.allLaunches { [weak self] (result) in
+
+            do {
+                let launches = try result.get()
+                self?.launchesUpdated?(launches)
+
+            } catch {
+
+            }
+        }
+    }
 }

--- a/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+struct LaunchesViewModel {
+}

--- a/RocketFan/Feature/Launches/Shared/LaunchesDependencyContainer.swift
+++ b/RocketFan/Feature/Launches/Shared/LaunchesDependencyContainer.swift
@@ -1,11 +1,19 @@
 import Foundation
 
 class LaunchesDependencyContainer: DependencyContainer, LaunchesViewControllerFactory {
-
     func makeLaunchesViewController() -> LaunchesViewController {
-        let api = makeSpaceXAPI()
-        let repo = LaunchesRepository(with: api)
+        return LaunchesViewController(with: makeViewModel())
+    }
+}
 
-        return LaunchesViewController(with: repo)
+extension LaunchesDependencyContainer {
+    private func makeViewModel() -> LaunchesViewModel {
+        let repo = makeRepository()
+        return LaunchesViewModel(with: repo)
+    }
+
+    private func makeRepository() -> LaunchesRepository {
+        let api = makeSpaceXAPI()
+        return LaunchesRepository(with: api)
     }
 }

--- a/RocketFan/Feature/Launches/Shared/LaunchesRepository.swift
+++ b/RocketFan/Feature/Launches/Shared/LaunchesRepository.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SpaceXAPI
 
-struct LaunchesRepository {
-    private let api: SpaceXAPI
+struct LaunchesRepository: LaunchesRepositoryProtocol {
+    internal let api: SpaceXAPI
     private var sessionTask: URLSessionTask?
 
     init(with api: SpaceXAPI) {

--- a/RocketFan/Feature/Launches/Shared/LaunchesRepositoryProtocol.swift
+++ b/RocketFan/Feature/Launches/Shared/LaunchesRepositoryProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol LaunchesRepositoryProtocol: RepositoryProtocol {
+    mutating func allLaunches(completion: @escaping (Result<[Launch], Error>) -> Void)
+}

--- a/RocketFan/Protocols/Repository.swift
+++ b/RocketFan/Protocols/Repository.swift
@@ -1,0 +1,6 @@
+import Foundation
+import SpaceXAPI
+
+protocol RepositoryProtocol {
+    var api: SpaceXAPI { get }
+}

--- a/RocketFanTests/Feature/Launches/LaunchesViewModelTests.swift
+++ b/RocketFanTests/Feature/Launches/LaunchesViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import RocketFan
+
+class LaunchesViewModelTests: XCTestCase {
+    private var sut: LaunchesViewModel?
+
+    override func setUp() {
+        sut = viewModel(with: loadLaunchs())
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    func test_DidSetOnLaunchesUpdated_LoadsLaunches() {
+        let exp = expectation(description: "Check launches are loaded")
+        var launchesCount = 0
+
+        sut?.launchesUpdated = { launches in
+            launchesCount = launches.count
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 5) { (error) in
+            if let error = error {
+                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
+            }
+
+            XCTAssertTrue(launchesCount > 0)
+        }
+    }
+
+    func test_WhenErrorCondition_CallsModelError() {
+        var modelErrorCalled = false
+        let exp = expectation(description: "Check model error is called")
+
+        sut = viewModel(with: nil)
+
+        sut?.modelError = { error in
+            modelErrorCalled = true
+            exp.fulfill()
+        }
+
+        // Makes the 'call' in 'didSet'
+        sut?.launchesUpdated = { _ in }
+
+        waitForExpectations(timeout: 5) { (error) in
+            if let error = error {
+                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
+            }
+
+            XCTAssertTrue(modelErrorCalled)
+        }
+    }
+}
+
+// Helpers
+extension LaunchesViewModelTests {
+    private func loadLaunchs() -> [Launch]? {
+        let json = JSONLoader.load(.launches)!
+        let decoder = JSONDecoder(dateDecodingStrategy: .secondsSince1970)
+        return try? decoder.decoded([Launch].self, from: json)
+    }
+
+    private func viewModel(with launches: [Launch]?) -> LaunchesViewModel {
+        let mockRepo = MockLaunchesRepository(with: launches)
+        return LaunchesViewModel(with: mockRepo)
+    }
+}

--- a/RocketFanTests/Feature/Launches/Mocks/MockLaunchesRepository.swift
+++ b/RocketFanTests/Feature/Launches/Mocks/MockLaunchesRepository.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SpaceXAPI
+
+@testable import RocketFan
+
+struct MockLaunchesRepository: LaunchesRepositoryProtocol {
+    private let launches: [Launch]?
+
+    internal var api: SpaceXAPI {
+        return SpaceXAPI(urlSession: URLSession.shared)
+    }
+
+    init(with launches: [Launch]?) {
+        self.launches = launches
+    }
+
+    mutating func allLaunches(completion: @escaping (Result<[Launch], Error>) -> Void) {
+        guard let launches = launches else {
+            let errorTemp = NSError(domain: "", code: 400, userInfo: nil)
+            completion(.failure(errorTemp))
+            return
+        }
+
+        completion(.success(launches))
+    }
+}


### PR DESCRIPTION
Relates to [#45](https://github.com/RocketFanOrg/RocketFanApp/issues/48)

Since I am about to add more logic to the `LaunchesViewController` it was time for a `ViewModel`
The `LaunchesRepository` has been moved into the `LaunchesViewModel` as it is no longer needed in the VC. 

With this approach `LaunchesViewController` has become much cleaner! 😃

**Testing**

~~I am not comfortable with testing async code and since the VM is pretty much a wrapper around all the async tasks (with some other logic coming), I am having a little trouble figuring it out. Once I know more about this area of unit testing I will update the code accordingly.~~

**Other considerations**

I had thought about making a `ViewModelFactory` protocol; however I am not sure wha the benefit will be, besides testing the VC and injecting a mock VM. Perhaps I will revisit this. 