### PR TITLE
Feature/launches - SearchEngine and ViewModel

### DIFF
--- a/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
@@ -15,6 +15,18 @@ class LaunchesViewModel {
 }
 
 extension LaunchesViewModel {
+    func findLaunchesMatching(_ searchTerm: String) {
+        guard searchTerm.isEmpty == false else {
+            loadPastLaunches()
+            return
+        }
+
+        let results = searchEngine?.launchesWhere(missionNameContains: searchTerm)
+        launchesUpdated?(results ?? [])
+    }
+}
+
+extension LaunchesViewModel {
     private func fetchAllLaunches() {
         repository?.allLaunches { [weak self] (result) in
 

--- a/RocketFan/Feature/Launches/All/SearchEngine.swift
+++ b/RocketFan/Feature/Launches/All/SearchEngine.swift
@@ -9,13 +9,14 @@ struct SearchEngine {
 }
 
 extension SearchEngine {
-    func launches(before date: Date) -> [Launch] {
+    func launches(before date: Date, withMissionName missionName: String = "") -> [Launch] {
         let validLaunches = launches.filter { $0.launchDate != nil }
-        return validLaunches.filter { $0.launchDate! < date }
+        return validLaunches.filter { $0.launchDate! < date && partialMatches($0.missionName, with: missionName) }
     }
 
-    func launches(after date: Date) -> [Launch] {
-        return launches.filter { $0.launchDate == nil || $0.launchDate! >= date }
+    func launches(after date: Date, withMissionName missionName: String = "") -> [Launch] {
+        let validLaunches = launches.filter { $0.launchDate == nil || $0.launchDate! >= date }
+        return validLaunches.filter { partialMatches($0.missionName, with: missionName) }
     }
 
     func launchesWhere(missionNameContains searchTerm: String) -> [Launch] {
@@ -27,6 +28,7 @@ extension SearchEngine {
 
 extension SearchEngine {
     private func partialMatches(_ string: String, with stringB: String) -> Bool {
+        guard stringB.isEmpty == false else { return true } // won't match against empty strings
 
         // lowercased, trim whitespace and newline for better results
         let firstString = string.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)

--- a/RocketFanTests/Feature/Launches/LaunchesViewModelTests.swift
+++ b/RocketFanTests/Feature/Launches/LaunchesViewModelTests.swift
@@ -52,6 +52,57 @@ class LaunchesViewModelTests: XCTestCase {
             XCTAssertTrue(modelErrorCalled)
         }
     }
+
+    func test_GivenSearchTerm_ReturnsResults() {
+        let exp = expectation(description: "Check launchesUpdated called twice")
+        var launchesUpdatedCalledCount = 0
+        var launchesCount = 0
+
+        sut?.launchesUpdated = { launches in
+            launchesUpdatedCalledCount += 1
+
+            if launchesUpdatedCalledCount > 1 {
+                launchesCount = launches.count
+                exp.fulfill()
+            }
+        }
+
+        sut?.findLaunchesMatching("Fal")
+
+        waitForExpectations(timeout: 5) { (error) in
+            if let error = error {
+                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
+            }
+
+            XCTAssertTrue(launchesUpdatedCalledCount == 2)
+            XCTAssertTrue(launchesCount > 1)
+        }
+    }
+
+    func test_GivenEmptySearchTerm_ReturnsResults() {
+        let exp = expectation(description: "Check launchesUpdated returns results")
+        var launchesUpdatedCalledCount = 0
+        var launchesCount = 0
+
+        sut?.launchesUpdated = { launches in
+            launchesUpdatedCalledCount += 1
+
+            if launchesUpdatedCalledCount > 1 {
+                launchesCount = launches.count
+                exp.fulfill()
+            }
+        }
+
+        sut?.findLaunchesMatching("")
+
+        waitForExpectations(timeout: 5) { (error) in
+            if let error = error {
+                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
+            }
+
+            XCTAssertTrue(launchesCount > 1)
+        }
+    }
 }
 
 // Helpers

--- a/RocketFanTests/Feature/Launches/SearchEngineTests.swift
+++ b/RocketFanTests/Feature/Launches/SearchEngineTests.swift
@@ -24,6 +24,20 @@ class SearchEngineTests: XCTestCase {
         XCTAssertTrue(all(launches!, areBefore: date), "All launches must be before referenceDate")
     }
 
+    func test_GivenReferenceDateAndSearchTerm_ReturnsPastLaunches() {
+        let date = referenceDate()
+        let launches = sut?.launches(before: date, withMissionName: "Fal")
+
+        XCTAssertTrue(all(launches!, areBefore: date), "All launches must be before referenceDate")
+    }
+
+    func test_GivenReferenceDateAndSearchTerm_ReturnsFutureLaunches() {
+        let date = referenceDate()
+        let launches = sut?.launches(after: date, withMissionName: "GPS")
+
+        XCTAssertTrue(all(launches!, areAfter: date), "All launches must be after referenceDate")
+    }
+
     func test_GivenReferenceDate_ReturnsFutureLaunches() {
         let date = referenceDate()
         let upcomingLaunches = sut?.launches(after: date)
@@ -83,6 +97,8 @@ extension SearchEngineTests {
     }
 
     private func all(_ launaches: [Launch], areBefore date: Date) -> Bool {
+        guard launaches.isEmpty == false else { return false }
+
         let todaysDate = Date()
 
         for launch in launaches {
@@ -97,6 +113,8 @@ extension SearchEngineTests {
     }
 
     private func all(_ launaches: [Launch], areAfter date: Date) -> Bool {
+        guard launaches.isEmpty == false else { return false }
+
         let todaysDate = Date()
 
         for launch in launaches {
@@ -111,9 +129,6 @@ extension SearchEngineTests {
     }
 
     private func referenceDate() -> Date {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withFractionalSeconds]
-
-        return formatter.date(from: "2019-05-25T00:00:00.000Z")!
+        return Date(timeIntervalSince1970: 1559374462)
     }
 }


### PR DESCRIPTION
Relates to [#45](https://github.com/RocketFanOrg/RocketFanApp/issues/45)

**`SearchEngine.swift`**

I've extended the functionality  to match against past or future launches, with a search term - in this case a mission name,

This is in preparation for the UI logic, where a user can select future launches (Or past) and then refine those results by a given search term. 

**Tests**

I've added additional tests to cover more use cases for `SearchEngine.swift` - and made the `referenceDate` simpler. 