### PR TITLE
Sorted Launches using Comparable

### DIFF
--- a/RocketFan/App/Models/Launch.swift
+++ b/RocketFan/App/Models/Launch.swift
@@ -166,3 +166,19 @@ extension Launch.Rocket {
         firstStage = try firstStageContainer.decode([Core].self, forKey: .cores)
     }
 }
+
+extension Launch: Comparable {
+    static func < (lhs: Launch, rhs: Launch) -> Bool {
+        guard let lhsDate = lhs.launchDate else { return false }
+        guard let rhsDate = rhs.launchDate else { return false }
+
+        return lhsDate < rhsDate
+    }
+
+    static func == (lhs: Launch, rhs: Launch) -> Bool {
+        guard let lhsDate = lhs.launchDate else { return false }
+        guard let rhsDate = rhs.launchDate else { return false }
+
+        return lhsDate == rhsDate
+    }
+}

--- a/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
+++ b/RocketFan/Feature/Launches/All/LaunchesViewModel.swift
@@ -50,12 +50,18 @@ extension LaunchesViewModel {
         var launches: [Launch]
 
         if filter == .past {
-            launches = searchEngine?.launches(before: Date(), withMissionName: missionName) ?? []
+            let unSortedLaunches = searchEngine?.launches(before: Date(), withMissionName: missionName) ?? []
+            launches = sort(unSortedLaunches, by: .descending)
         } else {
-            launches = searchEngine?.launches(after: Date(), withMissionName: missionName) ?? []
+           let unSortedLaunches = searchEngine?.launches(after: Date(), withMissionName: missionName) ?? []
+            launches = sort(unSortedLaunches, by: .ascending)
         }
 
         launchesUpdated?(launches)
+    }
+
+    private func sort(_ launches: [Launch], by sortOrder: SortOrder) -> [Launch] {
+        return sortOrder == .descending ? launches.sorted(by: >) : launches.sorted(by: <)
     }
 }
 
@@ -63,5 +69,10 @@ extension LaunchesViewModel {
     enum Filter {
         case past
         case upcoming
+    }
+
+    private enum SortOrder {
+        case descending
+        case ascending
     }
 }

--- a/RocketFanTests/Models/LaunchTests.swift
+++ b/RocketFanTests/Models/LaunchTests.swift
@@ -78,7 +78,7 @@ class LaunchTests: XCTestCase {
         XCTAssertEqual(launch?.flightClub, flightClub)
     }
 
-    func test_CanCompara_UsingComparable() {
+    func test_CanCompare_UsingComparable() {
         let firstLaunch = (launches?.first(where: { $0.flightNumber == 1 })!)!
         let secondLaunch = (launches?.first(where: { $0.flightNumber == 25 })!)!
         let unSortedLaunches = [secondLaunch, firstLaunch]

--- a/RocketFanTests/Models/LaunchTests.swift
+++ b/RocketFanTests/Models/LaunchTests.swift
@@ -77,4 +77,14 @@ class LaunchTests: XCTestCase {
         let flightClub = URL(string: "https://www.flightclub.io/results/?code=OG22")!
         XCTAssertEqual(launch?.flightClub, flightClub)
     }
+
+    func test_CanCompara_UsingComparable() {
+        let firstLaunch = (launches?.first(where: { $0.flightNumber == 1 })!)!
+        let secondLaunch = (launches?.first(where: { $0.flightNumber == 25 })!)!
+        let unSortedLaunches = [secondLaunch, firstLaunch]
+
+        let sorted = unSortedLaunches.sorted(by: <)
+
+        XCTAssertEqual(sorted.first, firstLaunch)
+    }
 }


### PR DESCRIPTION
Relates to [#65](https://github.com/RocketFanOrg/RocketFanApp/issues/65)

Past launches now sorted in descending - showing the last launch at the top of the list. 
Upcoming launches sorted using ascending - showing the next launch at the top of the list. 