### PR TITLE
Add primary button style files

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		0E2B86D1223B0E1E005686BB /* LandingPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2B86D0223B0E1E005686BB /* LandingPad.swift */; };
 		0E2B86D3223B0E30005686BB /* LandingPadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2B86D2223B0E30005686BB /* LandingPadTests.swift */; };
 		0E2B86D5223B1089005686BB /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2B86D4223B1089005686BB /* Location.swift */; };
+		0E3C842D22FD7B9800EC7EA6 /* RoundedButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3C842C22FD7B9800EC7EA6 /* RoundedButtonStyle.swift */; };
+		0E3C842F22FD7B9F00EC7EA6 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3C842E22FD7B9F00EC7EA6 /* PrimaryButton.swift */; };
 		0E5A282222F4E9EF0014251B /* LaunchDetailsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A282122F4E9EF0014251B /* LaunchDetailsHeaderView.swift */; };
 		0E611C11223312BE00F85DAB /* RocketFanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C10223312BE00F85DAB /* RocketFanTests.swift */; };
 		0E611C13223312C800F85DAB /* RocketFanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C12223312C800F85DAB /* RocketFanUITests.swift */; };
@@ -214,6 +216,8 @@
 		0E2B86D2223B0E30005686BB /* LandingPadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingPadTests.swift; sourceTree = "<group>"; };
 		0E2B86D4223B1089005686BB /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		0E2EA408223519D600A7D350 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
+		0E3C842C22FD7B9800EC7EA6 /* RoundedButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedButtonStyle.swift; sourceTree = "<group>"; };
+		0E3C842E22FD7B9F00EC7EA6 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		0E5A282122F4E9EF0014251B /* LaunchDetailsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDetailsHeaderView.swift; sourceTree = "<group>"; };
 		0E611C10223312BE00F85DAB /* RocketFanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanTests.swift; sourceTree = "<group>"; };
 		0E611C12223312C800F85DAB /* RocketFanUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanUITests.swift; sourceTree = "<group>"; };
@@ -401,6 +405,22 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		0E3C842A22FD7B7400EC7EA6 /* Styles */ = {
+			isa = PBXGroup;
+			children = (
+				0E3C842C22FD7B9800EC7EA6 /* RoundedButtonStyle.swift */,
+			);
+			path = Styles;
+			sourceTree = "<group>";
+		};
+		0E3C842B22FD7B8300EC7EA6 /* View Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				0E3C842E22FD7B9F00EC7EA6 /* PrimaryButton.swift */,
+			);
+			path = "View Modifiers";
+			sourceTree = "<group>";
+		};
 		0E69A6DE2292BEC3008DAFB6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -582,6 +602,8 @@
 		E11C1D4B22702AD7004C3972 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				0E3C842A22FD7B7400EC7EA6 /* Styles */,
+				0E3C842B22FD7B8300EC7EA6 /* View Modifiers */,
 				E11C1D4E22702D90004C3972 /* ViewControllers */,
 				0E10D811229EFD5B0041FDB4 /* Views */,
 			);
@@ -1103,6 +1125,7 @@
 				E18600DB2276308400B0C856 /* MainTabBarController.swift in Sources */,
 				0E2B86CF223B06A6005686BB /* Links.swift in Sources */,
 				E1BA53C52242DC3E00601E5C /* Rocket.swift in Sources */,
+				0E3C842D22FD7B9800EC7EA6 /* RoundedButtonStyle.swift in Sources */,
 				E1F34C54223CE05C00F22086 /* Mission.swift in Sources */,
 				E1F34C60223D4B2200F22086 /* Units.swift in Sources */,
 				0E69A6D9229291B8008DAFB6 /* LaunchDetailsViewModel.swift in Sources */,
@@ -1123,6 +1146,7 @@
 				E18600E42276372C00B0C856 /* LaunchesDependencyContainer.swift in Sources */,
 				E18600E62276378F00B0C856 /* LaunchesViewControllerFactory.swift in Sources */,
 				E1FFA03C223AA70E0056BA6B /* Data+Extensions.swift in Sources */,
+				0E3C842F22FD7B9F00EC7EA6 /* PrimaryButton.swift in Sources */,
 				0E5A282222F4E9EF0014251B /* LaunchDetailsHeaderView.swift in Sources */,
 				0EFA71D3223EE744006DC0F4 /* KeyedDecodingContainer+Extensions.swift in Sources */,
 			);

--- a/RocketFan/Feature/Shared/Styles/RoundedButtonStyle.swift
+++ b/RocketFan/Feature/Shared/Styles/RoundedButtonStyle.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct RoundedButtonStyle: ButtonStyle {
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .padding(8)
+            .background(Color.green)
+            .foregroundColor(.black)
+            .cornerRadius(8)
+            .scaleEffect(configuration.isPressed ? 0.95: 1)
+    }
+}

--- a/RocketFan/Feature/Shared/View Modifiers/PrimaryButton.swift
+++ b/RocketFan/Feature/Shared/View Modifiers/PrimaryButton.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct PrimaryButton: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .buttonStyle(RoundedButtonStyle())
+            .animation(.spring(response: 0.2, dampingFraction: 0.3, blendDuration: 0.5))
+    }
+}


### PR DESCRIPTION
This PR adds two files:

- `Feature > Shared > Styles > RoundedButtonStyle`: A rounded button style, which applies a scale effect when pressed
- `Feature > Shared > View Modifiers > PrimaryButtonStyle`: This applies the `RoundedButtonStyle`, and sets a small spring animation when pressed

**Notes:** the button style has deviated from the original design files, reasons listed below:

- Changed accent colour to `.green` after discussion on Slack
- Text color is set to `.black`, as this gives a color contrast ratio of 9.75:1. Using `.white` resulted in a contrast of 1.89:1, which is insufficent
- Corner radius is set to a simple fixed amount. I was able to create the 'pill button' effect using `.clipShape(Capsule())`. This looked great with text sizes less than `.accessibilityExtraLarge`. However on the larger accessibility sizes, it fell apart. 

See below for how this looks with both `.light` and `.dark` color schemes.

![ButtonStyle](https://user-images.githubusercontent.com/343450/62771418-106d4200-ba95-11e9-8722-62d3a5cee5b5.png)

## Usage

The above styles are applied to buttons as follows:

```swift
Button("CCAFS ABC") {
  /// Button action goes here
}
.modifier(PrimaryButton())
```