### PR TITLE
Pull Request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,30 @@
+## Checklist
+_Put an `x` in the boxes that apply._
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/RocketFanOrg/RocketFanApp/master/CONTRIBUTING.md) doc
+- [ ] Unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] My changes do not generate new SwiftLint warnings
+- [ ] Add GitHub issue #
+
+## Types of changes
+
+What types of changes does your code introduce to RocketFanApp?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Work done
+Give a brief summarized description of what the PR is for and the work done in it.
+
+## Notes
+Any additional notes will come here, use as below if no notes are required.
+
+Nothing extra 😉
+
+## Screenshots
+Please add screenshots of the different states found in this PR.


### PR DESCRIPTION
I feel we should have a standard on PRs going forward. A template will make opening PRs quicker and have a reminder of the kind of things we expect with new code changes. 

With this template, anytime a PR is created, the user will have this template already in the editor which makes things easy. 

Note that the CONTRIBUTING option in the checklist - the link doesn't work. We need to also create a `CONTRIBUTING.md` file at some point. We can have a blank one for now though. 