### PR TITLE
Add a navigation link view

### DIFF
--- a/RocketFan.xcodeproj/project.pbxproj
+++ b/RocketFan.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0E3C842D22FD7B9800EC7EA6 /* RoundedButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3C842C22FD7B9800EC7EA6 /* RoundedButtonStyle.swift */; };
 		0E3C842F22FD7B9F00EC7EA6 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3C842E22FD7B9F00EC7EA6 /* PrimaryButton.swift */; };
 		0E5A282222F4E9EF0014251B /* LaunchDetailsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A282122F4E9EF0014251B /* LaunchDetailsHeaderView.swift */; };
+		0E5F3C34237AD88D008583C9 /* NavigationLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5F3C33237AD88D008583C9 /* NavigationLinkView.swift */; };
 		0E611C11223312BE00F85DAB /* RocketFanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C10223312BE00F85DAB /* RocketFanTests.swift */; };
 		0E611C13223312C800F85DAB /* RocketFanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E611C12223312C800F85DAB /* RocketFanUITests.swift */; };
 		0E69A6D9229291B8008DAFB6 /* LaunchDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E69A6D8229291B8008DAFB6 /* LaunchDetailsViewModel.swift */; };
@@ -224,6 +225,7 @@
 		0E3C842C22FD7B9800EC7EA6 /* RoundedButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedButtonStyle.swift; sourceTree = "<group>"; };
 		0E3C842E22FD7B9F00EC7EA6 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		0E5A282122F4E9EF0014251B /* LaunchDetailsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDetailsHeaderView.swift; sourceTree = "<group>"; };
+		0E5F3C33237AD88D008583C9 /* NavigationLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLinkView.swift; sourceTree = "<group>"; };
 		0E611C10223312BE00F85DAB /* RocketFanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanTests.swift; sourceTree = "<group>"; };
 		0E611C12223312C800F85DAB /* RocketFanUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketFanUITests.swift; sourceTree = "<group>"; };
 		0E69A6D8229291B8008DAFB6 /* LaunchDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -605,7 +607,6 @@
 		13271488236739C600E90023 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				1327148923673A4000E90023 /* SettingsView.swift */,
 				1327148D23674F1C00E90023 /* Settings.swift */,
 			);
 			path = Settings;
@@ -790,6 +791,7 @@
 				E18600E12276365400B0C856 /* LaunchesRepository.swift */,
 				E1447532229C6246006D1E82 /* LaunchesRepositoryProtocol.swift */,
 				E18600E52276378F00B0C856 /* LaunchesViewControllerFactory.swift */,
+				0E5F3C33237AD88D008583C9 /* NavigationLinkView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1167,6 +1169,7 @@
 				E1BA53C52242DC3E00601E5C /* Rocket.swift in Sources */,
 				0E3C842D22FD7B9800EC7EA6 /* RoundedButtonStyle.swift in Sources */,
 				E1F34C54223CE05C00F22086 /* Mission.swift in Sources */,
+				0E5F3C34237AD88D008583C9 /* NavigationLinkView.swift in Sources */,
 				E1F34C60223D4B2200F22086 /* Units.swift in Sources */,
 				0E69A6D9229291B8008DAFB6 /* LaunchDetailsViewModel.swift in Sources */,
 				E11C1D5122702DB3004C3972 /* LoadingViewController.swift in Sources */,

--- a/RocketFan/Feature/Launches/Shared/NavigationLinkView.swift
+++ b/RocketFan/Feature/Launches/Shared/NavigationLinkView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct NavigationLinkView<Destination>: View where Destination: View {
+    let title: String
+    let buttonTitle: String
+    let destination: Destination
+
+    @State private var isActive = false
+
+    var body: some View {
+        HStack {
+            NavigationLink(destination: destination,
+                           isActive: $isActive,
+                           label: { EmptyView() })
+
+            Text(title)
+
+            Spacer()
+
+            Button(buttonTitle) {
+                self.isActive.toggle()
+            }
+            .modifier(PrimaryButton())
+        }
+    }
+}
+
+struct NavigationLinkView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationLinkView(title: "Mission",
+                           buttonTitle: "ABC DEF",
+                           destination: Text("Hello world")
+        )
+        .padding()
+    }
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketFanOrg/RocketFanApp/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] My changes do not generate new SwiftLint warnings
- [ ] Add GitHub issue #

## Types of changes

What types of changes does your code introduce to RocketFanApp?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Work done
This PR adds a new view which is intended for use as a way to link between views. For example, the Launch Details view will use this to allow a user to navigation to Rocket, and Launch Site detail views.

## Notes
Nothing extra 😉

## Screenshots
![Screenshot 2019-11-12 at 12 27 44](https://user-images.githubusercontent.com/343450/68671747-f0439800-0547-11ea-823d-ca224b514ec9.png)
