### PR TITLE
Update Danger gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    claide (1.0.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
@@ -11,43 +11,51 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.16.1)
+    danger (8.0.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
-      faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1.5)
-      kramdown (~> 1.5)
+      faraday (>= 0.9.0, < 2.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.7)
+      kramdown (~> 2.0)
+      kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-swiftlint (0.19.0)
+    danger-swiftlint (0.24.3)
       danger
       rake (> 10)
       thor (~> 0.19)
-    faraday (0.15.4)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
-    git (1.5.0)
-    kramdown (1.17.0)
-    multipart-post (2.0.0)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    git (1.7.0)
+      rchardet (~> 1.8)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.13.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    public_suffix (3.0.3)
+    public_suffix (4.0.5)
     rake (13.0.1)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    rchardet (1.8.0)
+    rexml (3.2.4)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -57,4 +65,4 @@ DEPENDENCIES
   danger-swiftlint
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
The old version was causing lint issues with binary files, see PR #107

Referece: https://github.com/danger/danger/issues/1055